### PR TITLE
Fix invalid json in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add a custom_components.json to components folder like:
   "name": "Name of Component",
   "owner": ["owner"],
   "manifest": "https://url/of/manifest.json",
-  "url": "https://url/of/component",
+  "url": "https://url/of/component"
 }
 ```
 


### PR DESCRIPTION
I copied and pasted the readme example and it leads to invalid json