### PR TITLE
Remove goldair_climate, incomplete requirements

### DIFF
--- a/components/goldair_climate.json
+++ b/components/goldair_climate.json
@@ -1,6 +1,0 @@
-{
-  "name": "goldair_climate",
-  "owner": ["nikrolls"],
-  "manifest": "https://raw.githubusercontent.com/nikrolls/homeassistant-goldair-climate/master/custom_components/goldair_climate/manifest.json",
-  "url": "https://github.com/nikrolls/homeassistant-goldair-climate"
-}


### PR DESCRIPTION
This PR removes the goldair_climate custom integration, as the requirements are incomplete and cause the CI to crash.

Raised an issue upstream:

<https://github.com/nikrolls/homeassistant-goldair-climate/issues/33>