### PR TITLE
Add digitalstrom component

### DIFF
--- a/components/digitalstrom.json
+++ b/components/digitalstrom.json
@@ -1,0 +1,7 @@
+{
+    "name": "digitalstrom",
+    "owner": ["lociii"],
+    "manifest": "https://raw.githubusercontent.com/lociii/homeassistant-digitalstrom/master/custom_components/digitalstrom/manifest.json",
+    "url": "https://github.com/lociii/homeassistant-digitalstrom"
+  }
+  


### PR DESCRIPTION
Component can be found on https://github.com/lociii/homeassistant-digitalstrom and requires pydigitalstrom which can be found on https://github.com/lociii/pydigitalstrom