### PR TITLE
Added hasl3 and reverted hasl

### DIFF
--- a/components/hasl.json
+++ b/components/hasl.json
@@ -1,6 +1,6 @@
 {
   "name": "hasl",
   "owner": ["DSorlov"],
-  "manifest": "https://raw.githubusercontent.com/hasl-sensor/integration/master/custom_components/hasl/manifest.json",
+  "manifest": "https://raw.githubusercontent.com/DSorlov/hasl-platform/hasl/custom_components/hasl/manifest.json",
   "url": "https://hasl.sorlov.com"
 }

--- a/components/hasl3.json
+++ b/components/hasl3.json
@@ -1,0 +1,6 @@
+{
+  "name": "hasl3",
+  "owner": ["DSorlov"],
+  "manifest": "https://raw.githubusercontent.com/hasl-sensor/integration/master/custom_components/hasl/manifest.json",
+  "url": "https://hasl.sorlov.com"
+}


### PR DESCRIPTION
Due to hasl beeing branched into two (v2 tree and v3 tree), changing the hasl to old repo and also adding the new hasl3 for the new integration. Sorry about the change and revert but got user feedback that was quite clear. =)