### PR TITLE
Add slack_user integration

### DIFF
--- a/components/slack_user.json
+++ b/components/slack_user.json
@@ -1,0 +1,9 @@
+{
+  "manifest": "https://raw.githubusercontent.com/GeorgeSG/ha-slack-user/master/custom_components/slack_user/manifest.json",
+  "name": "slack_user",
+  "owner": [
+    "@GeorgeSG"
+  ],
+  "url": "https://github.com/GeorgeSG/ha-slack-user"
+}
+


### PR DESCRIPTION
Adds metadata for [GeorgeSG/ha-slack-user](https://github.com/GeorgeSG/ha-slack-user).
Depends on [slackclient](https://pypi.org/project/slackclient/).

I know that the core [Slack Integration](https://www.home-assistant.io/integrations/slack/) also has the same dependency, so I'm not sure if I need to add this here :)