### PR TITLE
Add raincloud integration

### DIFF
--- a/components/raincloud.json
+++ b/components/raincloud.json
@@ -1,0 +1,6 @@
+{
+  "name": "raincloud",
+  "owner": ["vanstinator"],
+  "manifest": "https://raw.githubusercontent.com/vanstinator/hass-raincloud/master/custom_components/raincloud/manifest.json",
+  "url": "https://github.com/vanstinator/hass-raincloud"
+}


### PR DESCRIPTION
The official integration is a web scraper. I'm in the process of moving it to HACS and deprecating the official integration.