### PR TITLE
Add pymusiccast integration with speakers group

### DIFF
--- a/components/pymusiccast.json
+++ b/components/pymusiccast.json
@@ -1,0 +1,6 @@
+{
+  "name": "pymusiccast",
+  "owner": ["ppanagiotis"],
+  "manifest": "https://raw.githubusercontent.com/ppanagiotis/pymusiccast/master/manifest.json",
+  "url": "https://github.com/ppanagiotis/pymusiccast"
+}


### PR DESCRIPTION
Group MusicCast Yamaha Speakers with Home Assistant

Overwrite existing pymusiccast module to be able to group musiccast
yamaha speakers.