### PR TITLE
Rename pymusiccast to musiccast_yamaha

### DIFF
--- a/components/musiccast_yamaha.json
+++ b/components/musiccast_yamaha.json
@@ -1,0 +1,6 @@
+{
+  "name": "musiccast_yamaha",
+  "owner": ["ppanagiotis"],
+  "manifest": "https://raw.githubusercontent.com/ppanagiotis/pymusiccast/master/custom_components/musiccast_yamaha/manifest.json",
+  "url": "https://github.com/ppanagiotis/pymusiccast"
+}

--- a/components/pymusiccast.json
+++ b/components/pymusiccast.json
@@ -1,6 +1,0 @@
-{
-  "name": "pymusiccast",
-  "owner": ["ppanagiotis"],
-  "manifest": "https://raw.githubusercontent.com/ppanagiotis/pymusiccast/master/manifest.json",
-  "url": "https://github.com/ppanagiotis/pymusiccast"
-}


### PR DESCRIPTION
Pymusiccast is a little bit confusing, so use musiccast_yamaha