### PR TITLE
Add ge_kitchen custom component

### DIFF
--- a/components/ge_kitchen.json
+++ b/components/ge_kitchen.json
@@ -1,0 +1,6 @@
+{
+  "name": "GE Kitchen",
+  "owner": ["ajmarks"],
+  "manifest": "https://raw.githubusercontent.com/ajmarks/ajmarks_ha_components/master/ge_kitchen/manifest.json",
+  "url": "https://github.com/ajmarks/ajmarks_ha_components/tree/master/ge_kitchen"
+}


### PR DESCRIPTION
Custom component for GE Kitchen appliances, currently fairly limited because of a lack of appropriate entity types, but hopefully will expand.