### PR TITLE
Add HASS-S3

### DIFF
--- a/components/s3.json
+++ b/components/s3.json
@@ -1,0 +1,6 @@
+{
+    "name": "S3",
+    "owner": ["robmarkcole"],
+    "manifest": "https://raw.githubusercontent.com/robmarkcole/HASS-S3/master/custom_components/s3/manifest.json",
+    "url": "https://github.com/robmarkcole/HASS-S3"
+}


### PR DESCRIPTION
This adds a HASS-S3 integration someone else made. (Mainly so the [checks can pass](https://github.com/hacs/default/pull/494/checks?check_run_id=1016086440))