### PR TITLE
Add Satellite Tracker (N2YO) component

### DIFF
--- a/components/satellitetracker.json
+++ b/components/satellitetracker.json
@@ -1,0 +1,6 @@
+{
+  "name": "Satellite Tracker (N2YO)",
+  "owner": ["@djtimca"],
+  "manifest": "https://raw.githubusercontent.com/djtimca/hasatellitetracker/main/custom_components/satellitetracker/manifest.json",
+  "url": "https://github.com/djtimca/satellitetracker"
+}


### PR DESCRIPTION
Add the custom component for Satellite Tracker (N2YO) for inclusion in HACS.