### PR TITLE
Add HomeWizard Energy wheel

### DIFF
--- a/components/homewizard_energy.json
+++ b/components/homewizard_energy.json
@@ -1,0 +1,6 @@
+{
+  "name": "HomeWizard Energy",
+  "owner": ["Unsigus"],
+  "manifest": "https://raw.githubusercontent.com/Unsigus/hass-homewizard-energy/main/custom_components/homewizard_energy/manifest.json",
+  "url": "https://github.com/Unsigus/hass-homewizard-energy"
+}


### PR DESCRIPTION
Custom integration [HomeWizard Energy](https://github.com/Unsigus/hass-homewizard-energy) now makes use of an external library for IO.

As far as I know I now need to add this file here because it makes use of an external library. (The HACS validator was yelling to me I had to..). So here you go :), hope this is what you want!