### PR TITLE
Add Elasticsearch integration

### DIFF
--- a/components/elasticsearch.json
+++ b/components/elasticsearch.json
@@ -1,5 +1,5 @@
 {
-    "name": "elasticsearch",
+    "name": "Elasticsearch",
     "owner": ["legrego"],
     "manifest": "https://raw.githubusercontent.com/legrego/homeassistant-elasticsearch/master/custom_components/elastic/manifest.json",
     "url": "https://github.com/legrego/homeassistant-elasticsearch"

--- a/components/elasticsearch.json
+++ b/components/elasticsearch.json
@@ -1,0 +1,6 @@
+{
+    "name": "elasticsearch",
+    "owner": ["legrego"],
+    "manifest": "https://raw.githubusercontent.com/legrego/homeassistant-elasticsearch/master/custom_components/elastic/manifest.json",
+    "url": "https://github.com/legrego/homeassistant-elasticsearch"
+}


### PR DESCRIPTION
This adds a reference to the Elasticsearch integration hosted at https://github.com/legrego/homeassistant-elasticsearch