### PR TITLE
Remove nwsradar

### DIFF
--- a/components/nwsradar.json
+++ b/components/nwsradar.json
@@ -1,6 +1,0 @@
-{
-  "name": "National Weather Service Radar",
-  "owner": ["MatthewFlamm"],
-  "manifest": "https://raw.githubusercontent.com/MatthewFlamm/nwsradar/master/custom_components/nwsradar/manifest.json",
-  "url": "https://github.com/MatthewFlamm/nwsradar"
-}


### PR DESCRIPTION
This integration has already been removed from HACS and archived on GitHub, after removal of the NWS radar server used.