### PR TITLE
Re-add hass-AMS

### DIFF
--- a/components/ams.json
+++ b/components/ams.json
@@ -1,0 +1,6 @@
+{
+  "name": "Norwegian AMS HAN meter reader",
+  "owner": ["turbokongen"],
+  "manifest": "https://raw.githubusercontent.com/turbokongen/hass-AMS/master/custom_components/ams/manifest.json",
+  "url": "https://github.com/turbokongen/hass-AMS"
+}

--- a/components/ams.json
+++ b/components/ams.json
@@ -1,6 +1,6 @@
 {
   "name": "Norwegian AMS HAN meter reader",
-  "owner": ["turbokongen"],
+  "owner": ["@turbokongen"],
   "manifest": "https://raw.githubusercontent.com/turbokongen/hass-AMS/master/custom_components/ams/manifest.json",
   "url": "https://github.com/turbokongen/hass-AMS"
 }


### PR DESCRIPTION
Re-add hass-AMS after removal for not pinned package dependency.
Fixed in v1.2.1