### PR TITLE
Fixing Python requirements check

### DIFF
--- a/validate_requirements/validate_requirements.py
+++ b/validate_requirements/validate_requirements.py
@@ -99,7 +99,7 @@ def validate_requirements(requirements: Set[str]) -> bool:
     # Check for requirements incompatible with standard library.
     for version, std_libs in STD_LIBS.items():
         for req in all_integration_requirements:
-            if req in std_libs:
+            if req not in std_libs:
                 print(
                     f"Package {req} is not compatible "
                     f"with Python {version} standard library",


### PR DESCRIPTION
Action in my other [PR](https://github.com/home-assistant/wheels-custom-integrations/pull/313) has failed due to python requirement validation and it didn't make sense that `uuid` is absent in `python3.8`. I started looking closer and the check to find out that it has `not` missed in it's validation check.