### PR TITLE
Rename Google Home integration

### DIFF
--- a/components/google_home.json
+++ b/components/google_home.json
@@ -1,0 +1,6 @@
+{
+  "name": "Google Home",
+  "owner": ["@leikoilja"],
+  "manifest": "https://raw.githubusercontent.com/leikoilja/ha-google-home/master/custom_components/google_home/manifest.json",
+  "url": "https://github.com/leikoilja/ha-google-home"
+}

--- a/components/ha-google-home.json
+++ b/components/ha-google-home.json
@@ -1,6 +1,0 @@
-{
-  "name": "HA-Google-Home",
-  "owner": ["@leikoilja"],
-  "manifest": "https://raw.githubusercontent.com/leikoilja/ha-google-home/master/custom_components/ha-google-home/manifest.json",
-  "url": "https://github.com/leikoilja/ha-google-home"
-}


### PR DESCRIPTION
It's being renamed to follow naming standards in https://github.com/leikoilja/ha-google-home/pull/75
More context: https://github.com/leikoilja/ha-google-home/issues/69