### PR TITLE
Add RCT Power integration

### DIFF
--- a/components/rct_power.json
+++ b/components/rct_power.json
@@ -1,0 +1,8 @@
+{
+  "name": "RCT Power",
+  "owner": [
+    "@weltenwort"
+  ],
+  "manifest": "https://raw.githubusercontent.com/weltenwort/home-assistant-rct-power-integration/main/custom_components/rct_power/manifest.json",
+  "url": "https://github.com/weltenwort/home-assistant-rct-power-integration"
+}


### PR DESCRIPTION
## Summary

This adds the [RCT Power integration](https://github.com/weltenwort/home-assistant-rct-power-integration), which polls measurements from [RCT Power](https://www.rct-power.com/) inverters on the local network.