### PR TITLE
Ubee integration

### DIFF
--- a/components/ubee.json
+++ b/components/ubee.json
@@ -1,0 +1,6 @@
+{
+  "name": "Ubee Router",
+  "owner": ["@mzdrale", "@kevinhaendel"],
+  "manifest": "https://raw.githubusercontent.com/kevinhaendel/ha-ubee/main/custom_components/ubee/manifest.json",
+  "url": "https://github.com/kevinhaendel/ha-ubee"
+}


### PR DESCRIPTION
Added the ubee platform as custom integration since it was [removed](https://github.com/home-assistant/core/pull/43809) from Home Assistant.