### PR TITLE
Add Netia Player custom integration

### DIFF
--- a/components/netia_player.json
+++ b/components/netia_player.json
@@ -1,0 +1,6 @@
+{
+  "name": "Netia Player",
+  "owner": ["@korasinski"],
+  "manifest": "https://raw.githubusercontent.com/korasinski/ha-netia/master/custom_components/netia_player/manifest.json",
+  "url": "https://github.com/korasinski/ha-netia"
+}


### PR DESCRIPTION
Add a Netia Player custom integration (to integrate Home Assistant with Netia Player TV box using media_player domain).
