### PR TITLE
add signalmessenger integration

### DIFF
--- a/components/signalmessenger.json
+++ b/components/signalmessenger.json
@@ -1,6 +1,6 @@
 {
   "name": "signalmessenger",
   "owner": ["@agileek"],
-  "manifest": "https://github.com/agileek/hassio-addons/blob/master/custom_components/signalmessenger/manifest.json",
+  "manifest": "https://raw.githubusercontent.com/agileek/hassio-addons/master/custom_components/signalmessenger/manifest.json",
   "url": "https://github.com/agileek/hassio-addons/"
 }

--- a/components/signalmessenger.json
+++ b/components/signalmessenger.json
@@ -1,0 +1,6 @@
+{
+  "name": "signalmessenger",
+  "owner": ["@agileek"],
+  "manifest": "https://github.com/agileek/hassio-addons/blob/master/custom_components/signalmessenger/manifest.json",
+  "url": "https://github.com/agileek/hassio-addons/"
+}


### PR DESCRIPTION
I want to add this integration to hacs, it appears this is required since my integration uses python.

Related to https://github.com/agileek/hassio-addons/pull/29