### PR TITLE
renaming surepetcarebeta to sureha

### DIFF
--- a/components/sureha.json
+++ b/components/sureha.json
@@ -1,0 +1,6 @@
+{
+  "name": "Sure Petcare",
+  "owner": ["@benleb"],
+  "manifest": "https://raw.githubusercontent.com/benleb/surepetcare/dev/manifest.json",
+  "url": "https://github.com/benleb/surepetcare"
+}


### PR DESCRIPTION
Hey, I am renaming the `surepetcarebeta` integration to `sureha` due to the stupid decision of naming it almost as the official one. Sorry. As first step, I simply copied the `surepetcarebeta.json` file to `sureha.json`. In 2-3w I will do another PR which removes the old one completely.  Do you agree with this way? Or some optimizations recommended? 😅