### PR TITLE
Added manifest for cover_time_based_synced

### DIFF
--- a/components/cover_time_based_synced.json
+++ b/components/cover_time_based_synced.json
@@ -1,0 +1,6 @@
+{
+  "name": "cover_time_based_synced",
+  "owner": ["@kotborealis"],
+  "manifest": "https://raw.githubusercontent.com/kotborealis/home-assistant-custom-components-cover-time-based-synced/master/custom_components/cover_time_based_synced/manifest.json",
+  "url": "https://github.com/kotborealis/home-assistant-custom-components-cover-time-based-synced"
+}


### PR DESCRIPTION
# Proposed change

Add manifest for [cover_time_based_synced](https://github.com/kotborealis/home-assistant-custom-components-cover-time-based-synced) custom component

# Type of change

* [x] Attempting to create an integration for Lay-Z-Spa hot tubs
  * [x] I've opened up a PR for branding on Home Assistant Brands

# Additional information

* This PR fixes or closes issue: n/a
* Link to code base pull request: n/a
* Link to documentation pull request: n/a
* Link to integration documentation on our website: n/a