### PR TITLE
Rename to remove any chance of naming confusions

### DIFF
--- a/components/sureha.json
+++ b/components/sureha.json
@@ -1,6 +1,6 @@
 {
   "name": "Sure Petcare",
   "owner": ["@benleb"],
-  "manifest": "https://raw.githubusercontent.com/benleb/surepetcare/dev/manifest.json",
+  "manifest": "https://raw.githubusercontent.com/benleb/sureha/dev/manifest.json",
   "url": "https://github.com/benleb/sureha"
 }

--- a/components/sureha.json
+++ b/components/sureha.json
@@ -2,5 +2,5 @@
   "name": "Sure Petcare",
   "owner": ["@benleb"],
   "manifest": "https://raw.githubusercontent.com/benleb/surepetcare/dev/manifest.json",
-  "url": "https://github.com/benleb/surepetcare"
+  "url": "https://github.com/benleb/sureha"
 }


### PR DESCRIPTION
I know we had a similar PR already in the past… But the repo url changed now and it seems Hacs also wants the correct name blabla here ;) https://github.com/hacs/default/runs/3049261206?check_suite_focus=true

So, would be cool to merge ✌️ Thanks