### PR TITLE
Update and rename amber_electric.json to amberelectric.json

### DIFF
--- a/components/amber_electric.json
+++ b/components/amber_electric.json
@@ -1,8 +1,0 @@
-{
-    "name": "Amber Electric",
-    "owner": [
-        "@troykelly"
-    ],
-    "manifest": "https://raw.githubusercontent.com/troykelly/hacs-amberelectric/main/custom_components/amber_electric/manifest.json",
-    "url": "https://github.com/troykelly/hacs-amberelectric"
-}

--- a/components/amberelectric.json
+++ b/components/amberelectric.json
@@ -1,0 +1,8 @@
+{
+    "name": "Amber Electric",
+    "owner": [
+        "@madpilot"
+    ],
+    "manifest": "https://raw.githubusercontent.com/madpilot/hass-amber-electric/master/custom_components/amberelectric/manifest.json",
+    "url": "https://github.com/madpilot/hass-amber-electric"
+}


### PR DESCRIPTION
Moving to the official integration from an Amber dev, removing my original (now broken) integration.