### PR TITLE
Remove babybuddy.json

### DIFF
--- a/components/babybuddy.json
+++ b/components/babybuddy.json
@@ -1,6 +1,0 @@
-{
-  "name": "babybuddy",
-  "owner": ["@jcgoette"],
-  "manifest": "https://raw.githubusercontent.com/jcgoette/baby_buddy_homeassistant/master/custom_components/babybuddy/manifest.json",
-  "url": "https://github.com/jcgoette/baby_buddy_homeassistant"
-}


### PR DESCRIPTION
Removes babybuddy.json

It has no requirements key <https://raw.githubusercontent.com/jcgoette/baby_buddy_homeassistant/master/custom_components/babybuddy/manifest.json> and currently breaks our CI <https://github.com/home-assistant/wheels-custom-integrations/runs/3395581071?check_suite_focus=true>