### PR TITLE
Add here_weather

### DIFF
--- a/components/here_weather.json
+++ b/components/here_weather.json
@@ -1,0 +1,7 @@
+{
+    "name": "here_weather",
+    "owner": ["@eifinger"],
+    "manifest": "https://raw.githubusercontent.com/eifinger/hass-here-weather/master/custom_components/here_weather/manifest.json",
+    "url": "https://github.com/eifinger/hass-here-weather"
+  }
+  


### PR DESCRIPTION
Instead of adding the `here_weather` integration as an official integration, Martin and I [decided](https://github.com/home-assistant/core/pull/28910#issuecomment-913036090) it would be better to publish it as a custom component.