### PR TITLE
add omnik inverter integration

### DIFF
--- a/components/omnik_inverter.json
+++ b/components/omnik_inverter.json
@@ -1,0 +1,6 @@
+{
+    "name": "Omnik Inverter",
+    "owner": ["@klaasnicolaas","@robbinjanssen"],
+    "manifest": "https://raw.githubusercontent.com/robbinjanssen/home-assistant-omnik-inverter/master/custom_components/omnik_inverter/manifest.json",
+    "url": "https://github.com/robbinjanssen/home-assistant-omnik-inverter"
+}


### PR DESCRIPTION
Add Omnik Inverter integration
https://github.com/robbinjanssen/home-assistant-omnik-inverter

**Note**
Current manifest URL does not contain any dependencies yet, today there will be a
stable release that will also change this (see dev branch).