### PR TITLE
Add teleinfo custom component (needs pyserial)

### DIFF
--- a/components/teleinfo.json
+++ b/components/teleinfo.json
@@ -1,0 +1,6 @@
+{
+  "name": "teleinfo",
+  "owner": ["@sberthelot"],
+  "manifest": "https://raw.githubusercontent.com/sberthelot/teleinfo-home-assistant/main/custom_components/teleinfo/manifest.json",
+  "url": "https://github.com/sberthelot/teleinfo-home-assistant"
+}


### PR DESCRIPTION
Teleinfo component uses a specific serial dongle (french electricity network "Linky" interface)