### PR TITLE
Add custom integration for Samsung MDC Display

### DIFF
--- a/components/samsungmdc.json
+++ b/components/samsungmdc.json
@@ -1,0 +1,8 @@
+{
+    "name": "Samsung MDC Display",
+    "owner": [
+        "@matthijs2704"
+    ],
+    "manifest": "https://raw.githubusercontent.com/matthijs2704/homeassistant-samsungmdc/main/custom_components/samsungmdc/manifest.json",
+    "url": "https://github.com/matthijs2704/homeassistant-samsungmdc"
+}


### PR DESCRIPTION
Added custom integration wheels for my [Samsung MDC display](https://github.com/matthijs2704/homeassistant-samsungmdc) integration.
