### PR TITLE
Add mcp23017 component (removed from core)

### DIFF
--- a/components/mcp23017.json
+++ b/components/mcp23017.json
@@ -1,0 +1,6 @@
+{
+    "name": "mcp23017",
+    "owner": ["@jpcornil-git"],
+    "manifest": "https://github.com/jpcornil-git/HA-mcp23017/blob/main/custom_components/mcp23017/manifest.json",
+    "url": "https://github.com/jpcornil-git/HA-mcp23017"
+}

--- a/components/mcp23017.json
+++ b/components/mcp23017.json
@@ -1,6 +1,6 @@
 {
     "name": "mcp23017",
     "owner": ["@jpcornil-git"],
-    "manifest": "https://github.com/jpcornil-git/HA-mcp23017/blob/main/custom_components/mcp23017/manifest.json",
+    "manifest": "https://raw.githubusercontent.com/jpcornil-git/HA-mcp23017/master/custom_components/mcp23017/manifest.json",
     "url": "https://github.com/jpcornil-git/HA-mcp23017"
 }


### PR DESCRIPTION
Original mcp23017 integration has been removed (cfr. https://github.com/home-assistant/core/pull/67281).
This [custom integration](https://github.com/jpcornil-git/HA-mcp23017) restore support for that component thru HACS.