### PR TITLE
Remove HomeWizard Energy integration

### DIFF
--- a/components/homewizard_energy.json
+++ b/components/homewizard_energy.json
@@ -1,6 +1,0 @@
-{
-  "name": "HomeWizard Energy",
-  "owner": ["@DCSBL", "@unsigus"],
-  "manifest": "https://raw.githubusercontent.com/DCSBL/ha-homewizard-energy/main/custom_components/homewizard_energy/manifest.json",
-  "url": "https://github.com/DCSBL/ha-homewizard-energy"
-}


### PR DESCRIPTION
This project is added to core since 2022.2.

https://www.home-assistant.io/integrations/homewizard/
https://github.com/DCSBL/ha-homewizard-energy
https://github.com/hacs/default/pull/1407 (Remove from HACS request)