### PR TITLE
Migrate needed packages from old components

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -82,3 +82,4 @@ jobs:
           test: ${{ steps.test.outputs.is_test }}
           constraints: "constraints.txt"
           requirements: "requirements.txt"
+          apk: "libffi-dev;librrd-dev"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,8 +9,6 @@ on:
   pull_request:
     branches:
       - master
-    paths:
-      - requirements.txt
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -68,14 +68,6 @@ jobs:
         run: |
           touch .env_file
 
-      - name: Adjust build env
-        run: |
-          (
-            # cmake > 3.22.2 have issue on arm
-            # Tested until 3.22.5
-            echo "cmake==3.22.2"
-          ) >> constraints.txt
-
       - name: Build wheels
         uses: home-assistant/wheels@2022.06.7
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -68,6 +68,14 @@ jobs:
         run: |
           touch .env_file
 
+      - name: Adjust build env
+        run: |
+          (
+            # cmake > 3.22.2 have issue on arm
+            # Tested until 3.22.5
+            echo "cmake==3.22.2"
+          ) >> constraints.txt
+
       - name: Build wheels
         uses: home-assistant/wheels@2022.06.7
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -80,4 +80,4 @@ jobs:
           test: ${{ steps.test.outputs.is_test }}
           constraints: "constraints.txt"
           requirements: "requirements.txt"
-          apk: "libffi-dev;librrd-dev"
+          apk: "libffi-dev;rrdtool-dev"

--- a/components_old/aarlo.json
+++ b/components_old/aarlo.json
@@ -1,6 +1,0 @@
-{
-  "name": "aarlo",
-  "owner": ["@twrecked"],
-  "manifest": "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/custom_components/aarlo/manifest.json",
-  "url": "https://github.com/twrecked/hass-aarlo"
-}

--- a/components_old/abalin_nameday.json
+++ b/components_old/abalin_nameday.json
@@ -1,6 +1,0 @@
-{
-    "name": "Abalin Name Day API",
-    "owner": ["@viktak"],
-    "manifest": "https://raw.githubusercontent.com/viktak/ha-cc-abalin-nameday/main/custom_components/abalin_nameday/manifest.json",
-    "url": "https://github.com/viktak/ha-cc-abalin-nameday"
-}

--- a/components_old/abb_powerone_pvi_sunspec.json
+++ b/components_old/abb_powerone_pvi_sunspec.json
@@ -1,6 +1,0 @@
-{
-  "name": "ABB Power-One PVI SunSpec",
-  "owner": ["@alexdelprete"],
-  "manifest": "https://raw.githubusercontent.com/alexdelprete/ha-abb-powerone-pvi-sunspec/master/custom_components/abb_powerone_pvi_sunspec/manifest.json",
-  "url": "https://github.com/alexdelprete/ha-abb-powerone-pvi-sunspec"
-}

--- a/components_old/abfallplus.json
+++ b/components_old/abfallplus.json
@@ -1,7 +1,0 @@
-{
-  "name": "AbfallPlus",
-  "owner": ["@bouni"],
-  "manifest": "https://raw.githubusercontent.com/Bouni/abfallplus/master/custom_components/abfallplus/manifest.json",
-  "url": "https://github.com/Bouni/abfallplus"
-}
-

--- a/components_old/adax.json
+++ b/components_old/adax.json
@@ -1,6 +1,0 @@
-{
-    "name": "Adax",
-    "owner": ["@danielhiversen"],
-    "manifest": "https://raw.githubusercontent.com/Danielhiversen/home_assistant_adax/master/custom_components/adax/manifest.json",
-    "url": "https://github.com/Danielhiversen/home_assistant_adax/"
-}

--- a/components_old/airly.json
+++ b/components_old/airly.json
@@ -1,6 +1,0 @@
-{
-    "name": "Airly",
-    "owner": ["@bieniu"],
-    "manifest": "https://raw.githubusercontent.com/bieniu/ha-airly/master/custom_components/airly/manifest.json",
-    "url": "https://github.com/bieniu/ha-airly"
-}

--- a/components_old/airscape.json
+++ b/components_old/airscape.json
@@ -1,6 +1,0 @@
-{
-    "name": "Airscape Whole House Fan",
-    "owner": ["@quielb"],
-    "manifest": "https://raw.githubusercontent.com/quielb/hass-airscape/master/custom_components/airscape/manifest.json",
-    "url": "https://github.com/quielb/hass-airscape"
-}

--- a/components_old/alarmdotcom.json
+++ b/components_old/alarmdotcom.json
@@ -1,6 +1,0 @@
-{
-  "name": "Alarm.com",
-  "owner": ["@uvjustin"],
-  "manifest": "https://raw.githubusercontent.com/uvjustin/alarmdotcom/master/custom_components/alarmdotcom/manifest.json",
-  "url": "https://github.com/uvjustin/alarmdotcom"
-}

--- a/components_old/alexa_media.json
+++ b/components_old/alexa_media.json
@@ -1,6 +1,0 @@
-{
-  "name": "Alexa Media Player",
-  "owner": ["@keatontaylor", "@alandtse"],
-  "manifest": "https://raw.githubusercontent.com/custom-components/alexa_media_player/master/custom_components/alexa_media/manifest.json",
-  "url": "https://github.com/custom-components/alexa_media_player"
-}

--- a/components_old/alko.json
+++ b/components_old/alko.json
@@ -1,8 +1,0 @@
-{
-    "name": "alko",
-    "owner": [
-        "@jonkristian"
-    ],
-    "manifest": "https://raw.githubusercontent.com/jonkristian/alko/master/custom_components/alko/manifest.json",
-    "url": "https://github.com/jonkristian/alko"
-}

--- a/components_old/amberelectric.json
+++ b/components_old/amberelectric.json
@@ -1,8 +1,0 @@
-{
-    "name": "Amber Electric",
-    "owner": [
-        "@madpilot"
-    ],
-    "manifest": "https://raw.githubusercontent.com/madpilot/hass-amber-electric/master/custom_components/amberelectric/manifest.json",
-    "url": "https://github.com/madpilot/hass-amber-electric"
-}

--- a/components_old/ams.json
+++ b/components_old/ams.json
@@ -1,6 +1,0 @@
-{
-  "name": "Norwegian AMS HAN meter reader",
-  "owner": ["@turbokongen"],
-  "manifest": "https://raw.githubusercontent.com/turbokongen/hass-AMS/master/custom_components/ams/manifest.json",
-  "url": "https://github.com/turbokongen/hass-AMS"
-}

--- a/components_old/amshan.json
+++ b/components_old/amshan.json
@@ -1,6 +1,0 @@
-{
-  "name": "AMS HAN meter",
-  "owner": ["@toreamun"],
-  "manifest": "https://raw.githubusercontent.com/toreamun/amshan-homeassistant/master/custom_components/amshan/manifest.json",
-  "url": "https://github.com/toreamun/amshan-homeassistant"
-}

--- a/components_old/anniversaries.json
+++ b/components_old/anniversaries.json
@@ -1,6 +1,0 @@
-{	
-  "name": "anniversaries",	
-  "owner": ["@pinkywafer"],	
-  "manifest": "https://raw.githubusercontent.com/pinkywafer/Anniversaries/master/custom_components/anniversaries/manifest.json",	
-  "url": "https://github.com/pinkywafer/Anniversaries"	
-}

--- a/components_old/argon40.json
+++ b/components_old/argon40.json
@@ -1,6 +1,0 @@
-{
-  "name": "Argon40",
-  "owner": ["@Misiu"],
-  "manifest": "https://raw.githubusercontent.com/Misiu/argon40/master/custom_components/argon40/manifest.json",
-  "url": "https://github.com/Misiu/argon40"
-}

--- a/components_old/aria2.json
+++ b/components_old/aria2.json
@@ -1,6 +1,0 @@
-{
-  "name": "Aria2",
-  "owner": ["@tdeblock"],
-  "manifest": "https://raw.githubusercontent.com/deblockt/hass-aria2/main/custom_components/aria2/manifest.json",
-  "url": "https://github.com/deblockt/hass-aria2"
-}

--- a/components_old/arris_dcx960.json
+++ b/components_old/arris_dcx960.json
@@ -1,6 +1,0 @@
-{
-  "name": "Arris DCX960",
-  "owner": ["@Sholofly"],
-  "manifest": "https://raw.githubusercontent.com/Sholofly/arrisdcx960/dev/custom_components/arris_dcx960/manifest.json",
-  "url": "https://github.com/Sholofly/arrisdcx960"
-}

--- a/components_old/astroweather.json
+++ b/components_old/astroweather.json
@@ -1,6 +1,0 @@
-{
-    "name": "AstroWeather",
-    "owner": ["@mawinkler"],
-    "manifest": "https://raw.githubusercontent.com/mawinkler/astroweather/main/custom_components/astroweather/manifest.json",
-    "url": "https://github.com/mawinkler/astroweather"
-}

--- a/components_old/auroraplus.json
+++ b/components_old/auroraplus.json
@@ -1,6 +1,0 @@
-{
-  "name": "auroraplus",
-  "owner": ["@LeighCurran"],
-  "manifest": "https://raw.githubusercontent.com/LeighCurran/AuroraPlusHA/main/custom_components/auroraplus/manifest.json",
-  "url": "https://github.com/LeighCurran/AuroraPlusHA"
-}

--- a/components_old/automate.json
+++ b/components_old/automate.json
@@ -1,8 +1,0 @@
-{
-    "name": "Rollease Acmeda Automate Pulse Hub v2",
-    "owner": [
-        "@sillyfrog"
-    ],
-    "manifest": "https://raw.githubusercontent.com/sillyfrog/Automate-Pulse-v2/master/custom_components/automate/manifest.json",
-    "url": "https://github.com/sillyfrog/Automate-Pulse-v2"
-}

--- a/components_old/avanza_stock.json
+++ b/components_old/avanza_stock.json
@@ -1,6 +1,0 @@
-{
-  "name": "Avanza Stock",
-  "owner": ["@claha"],
-  "manifest": "https://raw.githubusercontent.com/custom-components/sensor.avanza_stock/master/custom_components/avanza_stock/manifest.json",
-  "url": "https://github.com/custom-components/sensor.avanza_stock"
-}

--- a/components_old/awox.json
+++ b/components_old/awox.json
@@ -1,6 +1,0 @@
-{
-    "name": "AwoX MESH control",
-    "owner": ["@fsaris"],
-    "manifest": "https://raw.githubusercontent.com/fsaris/home-assistant-awox/main/custom_components/awox/manifest.json",
-    "url": "https://github.com/fsaris/home-assistant-awox"
-}

--- a/components_old/aws_codepipeline.json
+++ b/components_old/aws_codepipeline.json
@@ -1,6 +1,0 @@
-{
-    "name": "AWS Codepipeline",
-    "owner": ["@rj175"],
-    "manifest": "https://raw.githubusercontent.com/rj175/home-assistant-aws-codepipeline/master/custom_components/aws_codepipeline/manifest.json",
-    "url": "https://github.com/rj175/home-assistant-aws-codepipeline"
-  }

--- a/components_old/balboa.json
+++ b/components_old/balboa.json
@@ -1,6 +1,0 @@
-{
-    "name": "Balboa Spa",
-    "owner": ["@garbled1"],
-    "manifest": "https://raw.githubusercontent.com/garbled1/balboa_homeassistan/master/custom_components/balboa/manifest.json",
-    "url": "https://github.com/garbled1/balboa_homeassistan"
-}

--- a/components_old/beoplay.json
+++ b/components_old/beoplay.json
@@ -1,6 +1,0 @@
-{
-  "name": "BeoPlay",
-  "owner": ["@giachello"],
-  "manifest": "https://raw.githubusercontent.com/giachello/beoplay/main/custom_components/beoplay/manifest.json",
-  "url": "https://github.com/giachello/beoplay"
-}

--- a/components_old/beward.json
+++ b/components_old/beward.json
@@ -1,6 +1,0 @@
-{
-  "name": "Beward Integration",
-  "owner": ["@Limych"],
-  "manifest": "https://raw.githubusercontent.com/Limych/ha-beward/dev/custom_components/beward/manifest.json",
-  "url": "https://github.com/Limych/ha-beward"
-}

--- a/components_old/ble_monitor.json
+++ b/components_old/ble_monitor.json
@@ -1,6 +1,0 @@
-{
-    "name": "Passive BLE monitor integration",
-    "owner": ["@Magalex2x14", "@Ernst79"],
-    "manifest": "https://raw.githubusercontent.com/custom-components/ble_monitor/master/custom_components/ble_monitor/manifest.json",
-    "url": "https://github.com/custom-components/ble_monitor"
-}

--- a/components_old/bobcatminer.json
+++ b/components_old/bobcatminer.json
@@ -1,6 +1,0 @@
-{
-  "name": "Bobcat Miner",
-  "owner": ["@ardevd"],
-  "manifest": "https://raw.githubusercontent.com/ardevd/ha-bobcatminer/main/custom_components/bobcatminer/manifest.json",
-  "url": "https://github.com/ardevd/ha-bobcatminer/"
-}

--- a/components_old/bosch.json
+++ b/components_old/bosch.json
@@ -1,6 +1,0 @@
-{
-    "name": "Bosch",
-    "owner": ["@pszafer"],
-    "manifest": "https://raw.githubusercontent.com/bosch-thermostat/home-assistant-bosch-custom-component/master/custom_components/bosch/manifest.json",
-    "url": "https://github.com/bosch-thermostat/home-assistant-bosch-custom-component"
-}

--- a/components_old/bosch_shc.json
+++ b/components_old/bosch_shc.json
@@ -1,6 +1,0 @@
-{
-    "name": "Bosch SHC",
-    "owner": ["@tschamm"],
-    "manifest": "https://raw.githubusercontent.com/tschamm/boschshc-hass/master/custom_components/bosch_shc/manifest.json",
-    "url": "https://github.com/tschamm/boschshc-hass"
-}

--- a/components_old/brandstofprijzen.json
+++ b/components_old/brandstofprijzen.json
@@ -1,6 +1,0 @@
-{
-    "name": "Brandstofprijzen",
-    "owner": ["@metbril"],
-    "manifest": "https://raw.githubusercontent.com/metbril/home-assistant-brandstofprijzen/main/custom_components/brandstofprijzen/manifest.json",
-    "url": "https://github.com/metbril/home-assistant-brandstofprijzen"
-}

--- a/components_old/braviatv_psk.json
+++ b/components_old/braviatv_psk.json
@@ -1,8 +1,0 @@
-{
-  "manifest": "https://raw.githubusercontent.com/custom-components/media_player.braviatv_psk/master/custom_components/braviatv_psk/manifest.json",
-  "name": "braviatv_psk",
-  "owner": [
-    "@gerard33"
-  ],
-  "url": "https://github.com/custom-components/media_player.braviatv_psk"
-}

--- a/components_old/candy.json
+++ b/components_old/candy.json
@@ -1,6 +1,0 @@
-{
-  "name": "Candy Simply-Fi",
-  "owner": ["@ofalvai"],
-  "manifest": "https://raw.githubusercontent.com/ofalvai/home-assistant-candy/main/custom_components/candy/manifest.json",
-  "url": "https://github.com/ofalvai/home-assistant-candy"
-}

--- a/components_old/carbon_intensity_uk.json
+++ b/components_old/carbon_intensity_uk.json
@@ -1,6 +1,0 @@
-{
-  "name": "Carbon Intensity UK",
-  "owner": ["@jscruz"],
-  "manifest": "https://raw.githubusercontent.com/jscruz/sensor.carbon_intensity_uk/master/custom_components/carbon_intensity_uk/manifest.json",
-  "url": "https://github.com/jscruz/sensor.carbon_intensity_uk"
-}

--- a/components_old/casambi.json
+++ b/components_old/casambi.json
@@ -1,6 +1,0 @@
-{
-  "name": "casambi",
-  "owner": ["@hellqvio86"],
-  "manifest": "https://raw.githubusercontent.com/hellqvio86/home_assistant_casambi/master/custom_components/casambi/manifest.json",
-  "url": "https://github.com/hellqvio86/home_assistant_casambi"
-}

--- a/components_old/casatunes.json
+++ b/components_old/casatunes.json
@@ -1,8 +1,0 @@
-{
-    "name": "casatunes",
-    "owner": [
-        "@jonkristian"
-    ],
-    "manifest": "https://raw.githubusercontent.com/jonkristian/casatunes/master/custom_components/casatunes/manifest.json",
-    "url": "https://github.com/jonkristian/casatunes"
-}

--- a/components_old/channels_dvr_recently_recorded.json
+++ b/components_old/channels_dvr_recently_recorded.json
@@ -1,6 +1,0 @@
-{
-  "name": "Channels DVR Recently Recorded",
-  "owner": ["@rccoleman"],
-  "manifest": "https://raw.githubusercontent.com/rccoleman/channels_dvr_recently_recorded/master/custom_components/channels_dvr_recently_recorded/manifest.json",
-  "url": "https://github.com/rccoleman/channels_dvr_recently_recorded"
-}

--- a/components_old/chargeamps.json
+++ b/components_old/chargeamps.json
@@ -1,9 +1,0 @@
-{
-	"name": "chargeamps",
-	"owner": [
-		"@kirei",
-		"@jschlyter"
-	],
-	"manifest": "https://raw.githubusercontent.com/kirei/hass-chargeamps/develop/custom_components/chargeamps/manifest.json",
-	"url": "https://github.com/kirei/hass-chargeamps"
-}

--- a/components_old/cleverspa.json
+++ b/components_old/cleverspa.json
@@ -1,6 +1,0 @@
-{
-  "name": "cleverspa",
-  "owner": ["@Wh1terat"],
-  "manifest": "https://raw.githubusercontent.com/Wh1terat/cleverspa-component/main/custom_components/cleverspa/manifest.json",
-  "url": "https://github.com/Wh1terat/cleverspa-component"
-}

--- a/components_old/climate_ip.json
+++ b/components_old/climate_ip.json
@@ -1,6 +1,0 @@
-{
-  "name": "Climate IP",
-  "owner": ["@atxbyea"],
-  "manifest": "https://raw.githubusercontent.com/atxbyea/samsungrac/master/custom_components/climate_ip/manifest.json",
-  "url": "https://github.com/atxbyea/samsungrac"
-}

--- a/components_old/compal_wifi.json
+++ b/components_old/compal_wifi.json
@@ -1,8 +1,0 @@
-{
-    "name": "Compal WiFi",
-    "owner": [
-        "@frimtec"
-    ],
-    "manifest": "https://raw.githubusercontent.com/frimtec/hass-compal-wifi/main/custom_components/compal_wifi/manifest.json",
-    "url": "https://github.com/frimtec/hass-compal-wifi"
-}

--- a/components_old/consul.json
+++ b/components_old/consul.json
@@ -1,6 +1,0 @@
-{
-  "name": "consul",
-  "owner": ["@jadson179"],
-  "manifest": "https://raw.githubusercontent.com/jadson179/consul/master/custom_components/consul/manifest.json",
-  "url": "https://github.com/jadson179/consul"
-}

--- a/components_old/creasoldombus.json
+++ b/components_old/creasoldombus.json
@@ -1,6 +1,0 @@
-{
-    "name": "Creasol DomBus RS485 modules",
-    "owner": ["@CreasolTech"],
-    "manifest": "https://raw.githubusercontent.com/CreasolTech/home-assistant-creasol-dombus/main/custom_components/creasoldombus/manifest.json",
-    "url": "https://github.com/CreasolTech/home-assistant-creasol-dombus"
-}

--- a/components_old/crownstone.json
+++ b/components_old/crownstone.json
@@ -1,6 +1,0 @@
-{
-  "name": "Crownstone",
-  "owner": ["@Crownstone","@RicArch97"],
-  "manifest": "https://raw.githubusercontent.com/crownstone/crownstone-home-assistant/master/custom_components/crownstone/manifest.json",
-  "url": "https://github.com/crownstone/crownstone-home-assistant"
-}

--- a/components_old/currentcost.json
+++ b/components_old/currentcost.json
@@ -1,6 +1,0 @@
-{
-    "name": "Current Cost",
-    "owner": ["@lolouk44"],
-    "manifest": "https://raw.githubusercontent.com/lolouk44/CurrentCost_HA_CC/master/custom_components/currentcost/manifest.json",
-    "url": "https://github.com/lolouk44/CurrentCost_HA_CC"
-}

--- a/components_old/daikin_altherma.json
+++ b/components_old/daikin_altherma.json
@@ -1,6 +1,0 @@
-{
-  "name": "Daikin Altherma",
-  "owner": ["@tadasdanielius"],
-  "manifest": "https://raw.githubusercontent.com/tadasdanielius/daikin_altherma/main/custom_components/daikin_altherma/manifest.json",
-  "url": "https://github.com/tadasdanielius/daikin_altherma"
-}

--- a/components_old/damda_evcharger.json
+++ b/components_old/damda_evcharger.json
@@ -1,6 +1,0 @@
-{
-  "name": "Damda EV",
-  "owner": ["@GuGu927"],
-  "manifest": "https://raw.githubusercontent.com/GuGu927/damda_evcharger/main/custom_components/damda_evcharger/manifest.json",
-  "url": "https://github.com/GuGu927/damda_evcharger"
-}

--- a/components_old/damda_weather.json
+++ b/components_old/damda_weather.json
@@ -1,6 +1,0 @@
-{
-  "name": "Damda Weather",
-  "owner": ["@GuGu927"],
-  "manifest": "https://raw.githubusercontent.com/GuGu927/damda_weather/main/custom_components/damda_weather/manifest.json",
-  "url": "https://github.com/GuGu927/damda_weather"
-}

--- a/components_old/danfoss_ally.json
+++ b/components_old/danfoss_ally.json
@@ -1,6 +1,0 @@
-{
-  "name": "Danfoss Ally",
-  "owner": ["@mtrab"],
-  "manifest": "https://raw.githubusercontent.com/MTrab/danfoss_ally/main/custom_components/danfoss_ally/manifest.json",
-  "url": "https://github.com/MTrab/danfoss_ally"
-}

--- a/components_old/deebot.json
+++ b/components_old/deebot.json
@@ -1,6 +1,0 @@
-{
-  "name": "Deebot 4 Home Assistant",
-  "owner": ["@DeebotUniverse", "@edenhaus"],
-  "manifest": "https://raw.githubusercontent.com/DeebotUniverse/Deebot-4-Home-Assistant/main/custom_components/deebot/manifest.json",
-  "url": "https://github.com/DeebotUniverse/Deebot-4-Home-Assistant"
-}

--- a/components_old/deltasol.json
+++ b/components_old/deltasol.json
@@ -1,6 +1,0 @@
-{
-  "name": "Deltasol KM2",
-  "owner": ["@dm82m"],
-  "manifest": "https://raw.githubusercontent.com/dm82m/hass-Deltasol-KM2/master/custom_components/deltasol/manifest.json",
-  "url": "https://github.com/dm82m/hass-Deltasol-KM2"
-}

--- a/components_old/denonavr3806.json
+++ b/components_old/denonavr3806.json
@@ -1,8 +1,0 @@
-{
-    "name": "denonavr3806",
-    "owner": [
-        "@troykelly"
-    ],
-    "manifest": "https://raw.githubusercontent.com/troykelly/hacs-denonavr3806/main/custom_components/denonavr3806/manifest.json",
-    "url": "https://github.com/troykelly/hacs-denonavr3806"
-}

--- a/components_old/digitalstrom.json
+++ b/components_old/digitalstrom.json
@@ -1,7 +1,0 @@
-{
-    "name": "digitalstrom",
-    "owner": ["@lociii"],
-    "manifest": "https://raw.githubusercontent.com/lociii/homeassistant-digitalstrom/master/custom_components/digitalstrom/manifest.json",
-    "url": "https://github.com/lociii/homeassistant-digitalstrom"
-  }
-  

--- a/components_old/dijnet.json
+++ b/components_old/dijnet.json
@@ -1,6 +1,0 @@
-{
-  "name": "dijnet",
-  "owner": ["@laszlojakab"],
-  "manifest": "https://raw.githubusercontent.com/laszlojakab/homeassistant-dijnet/master/custom_components/dijnet/manifest.json",
-  "url": "https://github.com/laszlojakab/homeassistant-dijnet"
-}

--- a/components_old/dobiss.json
+++ b/components_old/dobiss.json
@@ -1,6 +1,0 @@
-{
-    "name": "dobiss",
-    "owner": ["@kesteraernoudt"],
-    "manifest": "https://raw.githubusercontent.com/kesteraernoudt/dobiss/master/custom_components/dobiss/manifest.json",
-    "url": "https://github.com/kesteraernoudt/dobiss"
-}

--- a/components_old/drkblutspende.json
+++ b/components_old/drkblutspende.json
@@ -1,7 +1,0 @@
-{
-  "name": "DRK Blutspende",
-  "owner": ["@bouni"],
-  "manifest": "https://raw.githubusercontent.com/Bouni/drkblutspende/master/custom_components/drkblutspende/manifest.json",
-  "url": "https://github.com/Bouni/drkblutspende"
-}
-

--- a/components_old/drone_mobile.json
+++ b/components_old/drone_mobile.json
@@ -1,6 +1,0 @@
-{
-  "name": "drone_mobile",
-  "owner": ["@bjhiltbrand"],
-  "manifest": "https://raw.githubusercontent.com/bjhiltbrand/drone_mobile_home_assistant/main/custom_components/drone_mobile/manifest.json",
-  "url": "https://github.com/bjhiltbrand/drone_mobile_home_assistant"
-}

--- a/components_old/duke_energy_gateway.json
+++ b/components_old/duke_energy_gateway.json
@@ -1,6 +1,0 @@
-{
-  "name": "Duke Energy Gateway",
-  "owner": ["@mjmeli"],
-  "manifest": "https://raw.githubusercontent.com/mjmeli/ha-duke-energy-gateway/main/custom_components/duke_energy_gateway/manifest.json",
-  "url": "https://github.com/mjmeli/ha-duke-energy-gateway"
-}

--- a/components_old/duolingo.json
+++ b/components_old/duolingo.json
@@ -1,6 +1,0 @@
-{
-    "name": "Duolinguist",
-    "owner": ["@sphanley"],
-    "manifest": "https://raw.githubusercontent.com/sphanley/Duolinguist/master/custom_components/duolingo/manifest.json",
-    "url": "https://github.com/sphanley/Duolinguist"
-}  

--- a/components_old/dwd_weather.json
+++ b/components_old/dwd_weather.json
@@ -1,6 +1,0 @@
-{
-    "name": "Deutscher Wetterdienst",
-    "owner": ["@FL550"],
-    "manifest": "https://raw.githubusercontent.com/FL550/dwd_weather/master/custom_components/dwd_weather/manifest.json",
-    "url": "https://github.com/FL550/dwd_weather"
-}

--- a/components_old/easee.json
+++ b/components_old/easee.json
@@ -1,6 +1,0 @@
-{
-  "name": "Easee EV charger",
-  "owner": ["@fondberg"],
-  "manifest": "https://raw.githubusercontent.com/fondberg/easee_hass/master/custom_components/easee/manifest.json",
-  "url": "https://github.com/fondberg/easee_hass"
-}

--- a/components_old/easycontrols.json
+++ b/components_old/easycontrols.json
@@ -1,6 +1,0 @@
-{
-    "name": "easycontrols",
-    "owner": ["@laszlojakab"],
-    "manifest": "https://raw.githubusercontent.com/laszlojakab/homeassistant-easycontrols/master/custom_components/easycontrols/manifest.json",
-    "url": "https://github.com/laszlojakab/homeassistant-easycontrols"
-}

--- a/components_old/echonetlite.json
+++ b/components_old/echonetlite.json
@@ -1,6 +1,0 @@
-{
-    "name": "ECHONETLite",
-    "owner": ["@scottyphillips"],
-    "manifest": "https://raw.githubusercontent.com/scottyphillips/echonetlite_homeassistant/master/custom_components/echonetlite/manifest.json",
-    "url": "https://github.com/scottyphillips/echonetlite_homeassistant"
-}

--- a/components_old/ecodevices.json
+++ b/components_old/ecodevices.json
@@ -1,6 +1,0 @@
-{
-  "name": "GCE Eco-Devices",
-  "owner": ["@Aohzan"],
-  "manifest": "https://raw.githubusercontent.com/Aohzan/ecodevices/master/custom_components/ecodevices/manifest.json",
-  "url": "https://github.com/Aohzan/ecodevices"
-}

--- a/components_old/ecodevices_rt2.json
+++ b/components_old/ecodevices_rt2.json
@@ -1,6 +1,0 @@
-{
-  "name": "Ecodevices RT2",
-  "owner": ["@pcourbin"],
-  "manifest": "https://raw.githubusercontent.com/pcourbin/ecodevices_rt2/master/custom_components/ecodevices_rt2/manifest.json",
-  "url": "https://github.com/pcourbin/ecodevices_rt2"
-}

--- a/components_old/ecowater_softener.json
+++ b/components_old/ecowater_softener.json
@@ -1,6 +1,0 @@
-{
-    "name": "Ecowater Softener",
-    "owner": ["@barleybobs"],
-    "manifest": "https://raw.githubusercontent.com/barleybobs/homeassistant-ecowater-softener/main/custom_components/ecowater_softener/manifest.json",
-    "url": "https://github.com/barleybobs/homeassistant-ecowater-softener/"
-}

--- a/components_old/ecowitt.json
+++ b/components_old/ecowitt.json
@@ -1,6 +1,0 @@
-{
-    "name": "Ecowitt Weather Station",
-    "owner": ["@garbled1"],
-    "manifest": "https://raw.githubusercontent.com/garbled1/homeassistant_ecowitt/master/custom_components/ecowitt/manifest.json",
-    "url": "https://github.com/garbled1/homeassistant_ecowitt"
-}

--- a/components_old/edge_tts.json
+++ b/components_old/edge_tts.json
@@ -1,6 +1,0 @@
-{
-  "name": "edge_tts",
-  "owner": ["@al-one"],
-  "manifest": "https://raw.githubusercontent.com/hasscc/hass-edge-tts/main/custom_components/edge_tts/manifest.json",
-  "url": "https://github.com/hasscc/hass-edge-tts"
-}

--- a/components_old/egauge.json
+++ b/components_old/egauge.json
@@ -1,6 +1,0 @@
-{
-  "name": "eGauge",
-  "owner": ["@neggert"],
-  "manifest": "https://raw.githubusercontent.com/neggert/hass-egauge/master/custom_components/egauge/manifest.json",
-  "url": "https://github.com/neggert/hass-egauge"
-}

--- a/components_old/elasticsearch.json
+++ b/components_old/elasticsearch.json
@@ -1,6 +1,0 @@
-{
-    "name": "Elasticsearch",
-    "owner": ["@legrego"],
-    "manifest": "https://raw.githubusercontent.com/legrego/homeassistant-elasticsearch/master/custom_components/elasticsearch/manifest.json",
-    "url": "https://github.com/legrego/homeassistant-elasticsearch"
-}

--- a/components_old/emscrss.json
+++ b/components_old/emscrss.json
@@ -1,7 +1,0 @@
-{
-    "name": "EMSC Earthquake RSS Feed",
-    "owner": ["@msekoranja"],
-    "manifest": "https://raw.githubusercontent.com/msekoranja/emsc-hacs-repository/master/custom_components/emscrss/manifest.json",
-    "url": "https://github.com/msekoranja/emsc-hacs-repository"
-}
-

--- a/components_old/enasolar.json
+++ b/components_old/enasolar.json
@@ -1,6 +1,0 @@
-{
-    "name": "enasolar",
-    "owner": ["@geustace"],
-    "manifest": "https://raw.githubusercontent.com/geustace/home-assistant-enasolar/main/custom_components/enasolar/manifest.json",
-    "url": "https://github.com/geustace/home-assistant-enasolar/"
-}

--- a/components_old/enocean_custom.json
+++ b/components_old/enocean_custom.json
@@ -1,6 +1,0 @@
-{
-  "name": "EnOcean custom",
-  "owner": ["@pierrecle"],
-  "manifest": "https://raw.githubusercontent.com/pierrecle/enocean_custom/main/custom_components/enocean_custom/manifest.json",
-  "url": "https://github.com/pierrecle/enocean_custom"
-}

--- a/components_old/erse.json
+++ b/components_old/erse.json
@@ -1,6 +1,0 @@
-{
-  "name": "erse",
-  "owner": ["@dgomes"],
-  "manifest": "https://raw.githubusercontent.com/dgomes/ha_erse/master/custom_components/erse/manifest.json",
-  "url": "https://github.com/dgomes/ha_erse"
-}

--- a/components_old/eskom_loadshedding.json
+++ b/components_old/eskom_loadshedding.json
@@ -1,6 +1,0 @@
-{
-  "name": "Eskom Loadshedding Interface",
-  "owner": ["@swartjean"],
-  "manifest": "https://raw.githubusercontent.com/swartjean/ha-eskom-loadshedding/master/custom_components/eskom_loadshedding/manifest.json",
-  "url": "https://github.com/swartjean/ha-eskom-loadshedding"
-}

--- a/components_old/fireservicerota.json
+++ b/components_old/fireservicerota.json
@@ -1,6 +1,0 @@
-{
-  "name": "fireservicerota",
-  "owner": ["@cyberjunky"],
-  "manifest": "https://raw.githubusercontent.com/cyberjunky/home-assistant-fireservicerota/master/custom_components/fireservicerota/manifest.json",
-  "url": "https://github.com/cyberjunky/home-assistant-fireservicerota"
-}

--- a/components_old/fitx.json
+++ b/components_old/fitx.json
@@ -1,7 +1,0 @@
-{
-  "name": "FitX Gym Usage",
-  "owner": ["@Raukze"],
-  "manifest": "https://raw.githubusercontent.com/Raukze/home-assistant-fitx/main/custom_components/fitx/manifest.json",
-  "url": "https://github.com/Raukze/home-assistant-fitx/"
-}
-  

--- a/components_old/foldingathomecontrol.json
+++ b/components_old/foldingathomecontrol.json
@@ -1,6 +1,0 @@
-{
-  "name": "foldingathomecontrol",
-  "owner": ["@eifinger"],
-  "manifest": "https://raw.githubusercontent.com/eifinger/hass-foldingathomecontrol/master/custom_components/foldingathomecontrol/manifest.json",
-  "url": "https://github.com/eifinger/hass-foldingathomecontrol"
-}

--- a/components_old/fordpass.json
+++ b/components_old/fordpass.json
@@ -1,6 +1,0 @@
-{
-  "name": "fordpass",
-  "owner": ["@itchannel"],
-  "manifest": "https://raw.githubusercontent.com/itchannel/fordpass-ha/master/custom_components/fordpass/manifest.json",
-  "url": "https://github.com/itchannel/fordpass-ha"
-}

--- a/components_old/fortnite.json
+++ b/components_old/fortnite.json
@@ -1,6 +1,0 @@
-{
-  "name": "Fortnite Stats",
-  "owner": ["@michaellunzer"],
-  "manifest": "https://raw.githubusercontent.com/michaellunzer/Home-Assistant-Custom-Component-Fortnite/master/custom_components/fortnite/manifest.json",
-  "url": "https://github.com/michaellunzer/Home-Assistant-Custom-Component-Fortnite"
-}

--- a/components_old/fpa.json
+++ b/components_old/fpa.json
@@ -1,8 +1,0 @@
-{
-    "name": "Formula Pro Advanced WiFi",
-    "owner": [
-        "@joncar"
-    ],
-    "manifest": "https://raw.githubusercontent.com/joncar/ha-fpa/main/manifest.json",
-    "url": "https://github.com/joncar/ha-fpa"
-}

--- a/components_old/fpl_api.json
+++ b/components_old/fpl_api.json
@@ -1,6 +1,0 @@
-{
-  "name": "FPL Api",
-  "owner": ["@Hojland"],
-  "manifest": "https://raw.githubusercontent.com/Hojland/hass-fpl/main/custom_components/fpl_api/manifest.json",
-  "url": "https://github.com/Hojland/hass-fpl"
-}

--- a/components_old/fullykiosk.json
+++ b/components_old/fullykiosk.json
@@ -1,6 +1,0 @@
-{
-  "name": "Fully Kiosk Browser",
-  "owner": ["@cgarwood"],
-  "manifest": "https://raw.githubusercontent.com/cgarwood/homeassistant-fullykiosk/master/custom_components/fullykiosk/manifest.json",
-  "url": "https://github.com/cgarwood/homeassistant-fullykiosk"
-}

--- a/components_old/garbage_collection.json
+++ b/components_old/garbage_collection.json
@@ -1,6 +1,0 @@
-{
-    "name": "Garbage Collection",
-    "owner": ["@bruxy70"],
-    "manifest": "https://raw.githubusercontent.com/bruxy70/Garbage-Collection/master/custom_components/garbage_collection/manifest.json",
-    "url": "https://github.com/bruxy70/Garbage-Collection"
-}

--- a/components_old/gardena-smart-system.json
+++ b/components_old/gardena-smart-system.json
@@ -1,6 +1,0 @@
-{
-  "name": "Gardena Smart System integration",
-  "owner": ["@py-smart-gardena"],
-  "manifest": "https://raw.githubusercontent.com/py-smart-gardena/hass-gardena-smart-system/master/custom_components/gardena_smart_system/manifest.json",
-  "url": "https://github.com/py-smart-gardena/hass-gardena-smart-system"
-}

--- a/components_old/garmin_connect.json
+++ b/components_old/garmin_connect.json
@@ -1,6 +1,0 @@
-{
-    "name": "Garmin Connect",
-    "owner": ["@cyberjunky"],
-    "manifest": "https://raw.githubusercontent.com/cyberjunky/home-assistant-garmin_connect/main/custom_components/garmin_connect/manifest.json",
-    "url": "https://github.com/cyberjunky/home-assistant-garmin_connect"
-}

--- a/components_old/ge_home.json
+++ b/components_old/ge_home.json
@@ -1,6 +1,0 @@
-{
-  "name": "GE Home (SmartHQ)",
-  "owner": ["@simbaja"],
-  "manifest": "https://raw.githubusercontent.com/simbaja/ha_gehome/master/custom_components/ge_home/manifest.json",
-  "url": "https://github.com/simbaja/ha_gehome/tree/master/custom_components/ge_home"
-}

--- a/components_old/ge_kitchen.json
+++ b/components_old/ge_kitchen.json
@@ -1,6 +1,0 @@
-{
-  "name": "GE Kitchen",
-  "owner": ["@ajmarks"],
-  "manifest": "https://raw.githubusercontent.com/ajmarks/ha_components/master/ge_kitchen/manifest.json",
-  "url": "https://github.com/ajmarks/ha_components/tree/master/ge_kitchen"
-}

--- a/components_old/gecko.json
+++ b/components_old/gecko.json
@@ -1,6 +1,0 @@
-{
-    "name": "Gecko Spa",
-    "owner": ["@gazoodle"],
-    "manifest": "https://raw.githubusercontent.com/gazoodle/gecko-home-assistant/master/custom_components/gecko/manifest.json",
-    "url": "https://github.com/gazoodle/gecko-home-assistant"
-}

--- a/components_old/georide.json
+++ b/components_old/georide.json
@@ -1,8 +1,0 @@
-{
-  "name": "GeoRide",
-  "owner": [
-    "@ptimatth"
-  ],
-  "manifest": "https://raw.githubusercontent.com/ptimatth/GeorideHA/master/custom_components/georide/manifest.json",
-  "url": "https://github.com/ptimatth/GeorideHA"
-}

--- a/components_old/gios.json
+++ b/components_old/gios.json
@@ -1,6 +1,0 @@
-{
-    "name": "GIOŚ",
-    "owner": ["@bieniu"],
-    "manifest": "https://raw.githubusercontent.com/bieniu/ha-gios/master/custom_components/gios/manifest.json",
-    "url": "https://github.com/bieniu/ha-gios"
-}

--- a/components_old/goecharger.json
+++ b/components_old/goecharger.json
@@ -1,6 +1,0 @@
-{
-  "name": "go-eCharger",
-  "owner": ["@cathiele"],
-  "manifest": "https://raw.githubusercontent.com/cathiele/homeassistant-goecharger/master/custom_components/goecharger/manifest.json",
-  "url": "https://github.com/cathiele/homeassistant-goecharger"
-}

--- a/components_old/google_home.json
+++ b/components_old/google_home.json
@@ -1,6 +1,0 @@
-{
-  "name": "Google Home",
-  "owner": ["@leikoilja"],
-  "manifest": "https://raw.githubusercontent.com/leikoilja/ha-google-home/master/custom_components/google_home/manifest.json",
-  "url": "https://github.com/leikoilja/ha-google-home"
-}

--- a/components_old/googlewifi.json
+++ b/components_old/googlewifi.json
@@ -1,6 +1,0 @@
-{
-  "name": "Google WiFi",
-  "owner": ["@djtimca"],
-  "manifest": "https://raw.githubusercontent.com/djtimca/hagooglewifi/main/custom_components/googlewifi/manifest.json",
-  "url": "https://github.com/djtimca/hagooglewifi"
-}

--- a/components_old/govee.json
+++ b/components_old/govee.json
@@ -1,6 +1,0 @@
-{
-  "name": "Govee",
-  "owner": ["@LaggAt"],
-  "manifest": "https://raw.githubusercontent.com/LaggAt/hacs-govee/master/custom_components/govee/manifest.json",
-  "url": "https://github.com/LaggAt/hacs-govee"
-}

--- a/components_old/grocy.json
+++ b/components_old/grocy.json
@@ -1,6 +1,0 @@
-{
-    "name": "Grocy",
-    "owner": ["@SebRut", "@isabellaalstrom"],
-    "manifest": "https://raw.githubusercontent.com/custom-components/grocy/master/custom_components/grocy/manifest.json",
-    "url": "https://github.com/custom-components/grocy/"
-}

--- a/components_old/ha_pyamdgpuinfo.json
+++ b/components_old/ha_pyamdgpuinfo.json
@@ -1,6 +1,0 @@
-{
-  "name": "AMDGPU sensors",
-  "owner": ["@deadended"],
-  "manifest": "https://raw.githubusercontent.com/DeadEnded/ha-pyamdgpuinfo/main/custom_components/ha-pyamdgpuinfo/manifest.json",
-  "url": "https://github.com/DeadEnded/ha-pyamdgpuinfo"
-}

--- a/components_old/hasl.json
+++ b/components_old/hasl.json
@@ -1,6 +1,0 @@
-{
-  "name": "hasl",
-  "owner": ["@DSorlov"],
-  "manifest": "https://raw.githubusercontent.com/DSorlov/hasl-platform/master/custom_components/hasl/manifest.json",
-  "url": "https://hasl.sorlov.com"
-}

--- a/components_old/hasl3.json
+++ b/components_old/hasl3.json
@@ -1,6 +1,0 @@
-{
-  "name": "hasl3",
-  "owner": ["@DSorlov"],
-  "manifest": "https://raw.githubusercontent.com/hasl-sensor/integration/master/custom_components/hasl3/manifest.json",
-  "url": "https://hasl.sorlov.com"
-}

--- a/components_old/heatmiser_wifi.json
+++ b/components_old/heatmiser_wifi.json
@@ -1,6 +1,0 @@
-{
-    "name": "heatmiser_wifi",
-    "owner": ["@midstar"],
-    "manifest": "https://raw.githubusercontent.com/midstar/heatmiser_wifi_ha/master/custom_components/heatmiser_wifi/manifest.json",
-    "url": "https://github.com/midstar/heatmiser_wifi_ha/"
-}

--- a/components_old/heatzy.json
+++ b/components_old/heatzy.json
@@ -1,6 +1,0 @@
-{
-  "name": "Heatzy",
-  "owner": ["@cyr-ius"],
-  "manifest": "https://raw.githubusercontent.com/cyr-ius/hass-heatzy/master/custom_components/heatzy/manifest.json",
-  "url": "https://github.com/cyr-ius/hass-heatzy"
-}

--- a/components_old/hekr.json
+++ b/components_old/hekr.json
@@ -1,6 +1,0 @@
-{
-  "name": "Hekr",
-  "owner": ["@alryaz"],
-  "manifest": "https://raw.githubusercontent.com/alryaz/hass-hekr-component/master/custom_components/hekr/manifest.json",
-  "url": "https://github.com/alryaz/hass-hekr-component"
-}

--- a/components_old/helios.json
+++ b/components_old/helios.json
@@ -1,6 +1,0 @@
-{
-  "name": "Helios ventilation",
-  "owner": ["@asev"],
-  "manifest": "https://raw.githubusercontent.com/asev/homeassistant-helios/master/custom_components/helios/manifest.json",
-  "url": "https://github.com/asev/homeassistant-helios"
-}

--- a/components_old/helium.json
+++ b/components_old/helium.json
@@ -1,6 +1,0 @@
-{
-  "name": "Helium Blockchain",
-  "owner": ["@rsnodgrass"],
-  "manifest": "https://raw.githubusercontent.com/rsnodgrass/hass-helium/main/custom_components/helium/manifest.json",
-  "url": "https://github.com/rsnodgrass/hass-helium"
-}

--- a/components_old/hella_onyx.json
+++ b/components_old/hella_onyx.json
@@ -1,6 +1,0 @@
-{
-  "name": "Hella ONYX.CENTER",
-  "owner": ["@muhlba91"],
-  "manifest": "https://raw.githubusercontent.com/muhlba91/onyx-homeassistant-integration/next/custom_components/hella_onyx/manifest.json",
-  "url": "https://github.com/muhlba91/onyx-homeassistant-integration"
-}

--- a/components_old/here_weather.json
+++ b/components_old/here_weather.json
@@ -1,7 +1,0 @@
-{
-    "name": "here_weather",
-    "owner": ["@eifinger"],
-    "manifest": "https://raw.githubusercontent.com/eifinger/hass-here-weather/master/custom_components/here_weather/manifest.json",
-    "url": "https://github.com/eifinger/hass-here-weather"
-  }
-  

--- a/components_old/hi_mama.json
+++ b/components_old/hi_mama.json
@@ -1,6 +1,0 @@
-{
-  "name": "hi_mama",
-  "owner": ["@jcgoette"],
-  "manifest": "https://raw.githubusercontent.com/jcgoette/hi_mama_homeassistant/main/custom_components/hi_mama/manifest.json",
-  "url": "https://github.com/jcgoette/hi_mama_homeassistant"
-}

--- a/components_old/hikconnect.json
+++ b/components_old/hikconnect.json
@@ -1,6 +1,0 @@
-{
-  "name": "Hik-Connect",
-  "owner": ["@tomasbedrich"],
-  "manifest": "https://raw.githubusercontent.com/tomasbedrich/home-assistant-hikconnect/master/custom_components/hikconnect/manifest.json",
-  "url": "https://github.com/tomasbedrich/home-assistant-hikconnect"
-}

--- a/components_old/hive.json
+++ b/components_old/hive.json
@@ -1,6 +1,0 @@
-{
-  "name": "hive",
-  "owner": ["@Rendili", "@KJonline"],
-  "manifest": "https://raw.githubusercontent.com/Pyhive/HA-Hive-Custom-Component/master/custom_components/hive/manifest.json",
-  "url": "https://github.com/Pyhive/HA-Hive-Custom-Component"
-}

--- a/components_old/holidays.json
+++ b/components_old/holidays.json
@@ -1,6 +1,0 @@
-{
-    "name": "Holidays",
-    "owner": ["@bruxy70"],
-    "manifest": "https://raw.githubusercontent.com/bruxy70/Holidays/master/custom_components/holidays/manifest.json",
-    "url": "https://github.com/bruxy70/Holidays"
-}

--- a/components_old/homee.json
+++ b/components_old/homee.json
@@ -1,6 +1,0 @@
-{
-  "name": "homee",
-  "owner": ["@FreshlyBrewedCode"],
-  "manifest": "https://raw.githubusercontent.com/FreshlyBrewedCode/hacs-homee/master/custom_components/homee/manifest.json",
-  "url": "https://github.com/FreshlyBrewedCode/hacs-homee"
-}

--- a/components_old/homeeasy_local.json
+++ b/components_old/homeeasy_local.json
@@ -1,8 +1,0 @@
-{
-    "name": "Home Easy HVAC Local",
-    "owner": [
-        "@ki0ki0"
-    ],
-    "manifest": "https://raw.githubusercontent.com/ki0ki0/homeeasy_ha_local/master/custom_components/homeeasy_local/manifest.json",
-    "url": "https://github.com/ki0ki0/homeeasy_ha_local"
-}

--- a/components_old/honor_x3.json
+++ b/components_old/honor_x3.json
@@ -1,6 +1,0 @@
-{
-  "name": "honor_x3",
-  "owner": ["@juacas"],
-  "manifest": "https://raw.githubusercontent.com/juacas/honor_x3/master/custom_components/honor_x3/manifest.json",
-  "url": "https://github.com/juacas/honor_x3"
-}

--- a/components_old/hpprinter.json
+++ b/components_old/hpprinter.json
@@ -1,6 +1,0 @@
-{
-  "name": "HP Printer",
-  "owner": ["@elad-bar"],
-  "manifest": "https://raw.githubusercontent.com/elad-bar/ha-hpprinter/master/custom_components/hpprinter/manifest.json",
-  "url": "https://github.com/elad-bar/ha-hpprinter"
-}

--- a/components_old/hslhrt.json
+++ b/components_old/hslhrt.json
@@ -1,6 +1,0 @@
-{
-    "name": "Helsinki Regional Transport",
-    "owner": ["@anand-p-r"],
-    "manifest": "https://raw.githubusercontent.com/anand-p-r/hslhrt-hass-custom/main/manifest.json",
-    "url": "https://github.com/anand-p-r/hslhrt-hass-custom"
-  }

--- a/components_old/hubitat.json
+++ b/components_old/hubitat.json
@@ -1,6 +1,0 @@
-{
-	"name": "Hubitat",
-	"owner": ["@jason0x43"],
-	"manifest": "https://raw.githubusercontent.com/jason0x43/hacs-hubitat/master/custom_components/hubitat/manifest.json",
-	"url": "https://github.com/jason0x43/hacs-hubitat"
-}

--- a/components_old/huesyncbox.json
+++ b/components_old/huesyncbox.json
@@ -1,6 +1,0 @@
-{
-    "name": "Philips Hue Play HDMI Sync Box",
-    "owner": ["@mvdwetering"],
-    "manifest": "https://raw.githubusercontent.com/mvdwetering/huesyncbox/master/custom_components/huesyncbox/manifest.json",
-    "url": "https://github.com/mvdwetering/huesyncbox"
-}

--- a/components_old/husqvarna_automower.json
+++ b/components_old/husqvarna_automower.json
@@ -1,6 +1,0 @@
-{
-  "name": "Husqvarna Automower",
-  "owner": ["@Thomas55555"],
-  "manifest": "https://raw.githubusercontent.com/Thomas55555/husqvarna_automower/main/custom_components/husqvarna_automower/manifest.json",
-  "url": "https://github.com/Thomas55555/husqvarna_automower"
-}

--- a/components_old/hx3.json
+++ b/components_old/hx3.json
@@ -1,6 +1,0 @@
-{
-  "name": "hx3",
-  "owner": ["@jaredhobbs"],
-  "manifest": "https://raw.githubusercontent.com/jaredhobbs/home-assistant-hx3/master/custom_components/hx3/manifest.json",
-  "url": "https://github.com/jaredhobbs/home-assistant-hx3"
-}

--- a/components_old/ical.json
+++ b/components_old/ical.json
@@ -1,7 +1,0 @@
-{
-    "name": "iCal Sensor",
-    "owner": ["@Olen", "@TyBritten"],
-    "manifest": "https://raw.githubusercontent.com/tybritten/ical-sensor-homeassistant/master/custom_components/ical/manifest.json",
-    "url": "https://github.com/tybritten/ical-sensor-homeassistant/"
-  }
-  

--- a/components_old/imaprotect.json
+++ b/components_old/imaprotect.json
@@ -1,6 +1,0 @@
-{
-  "name": "IMA Protect Alarm",
-  "owner": ["@pcourbin"],
-  "manifest": "https://raw.githubusercontent.com/pcourbin/imaprotect/master/custom_components/imaprotect/manifest.json",
-  "url": "https://github.com/pcourbin/imaprotect"
-}

--- a/components_old/indego.json
+++ b/components_old/indego.json
@@ -1,6 +1,0 @@
-{
-  "name": "indego",
-  "owner": ["@jm73"],
-  "manifest": "https://raw.githubusercontent.com/jm-73/indego/master/custom_components/indego/manifest.json",
-  "url": "https://github.com/jm-73/Indego"
-}

--- a/components_old/ingv_centro_nazionale_terremoti.json
+++ b/components_old/ingv_centro_nazionale_terremoti.json
@@ -1,6 +1,0 @@
-{
-  "name": "INGV Centro Nazionale Terremoti",
-  "owner": ["@exxamalte", "@caiosweet"],
-  "manifest": "https://raw.githubusercontent.com/caiosweet/Home-Assistant-custom-components-INGV/main/custom_components/ingv_centro_nazionale_terremoti/manifest.json",
-  "url": "https://github.com/caiosweet/Home-Assistant-custom-components-INGV"
-}

--- a/components_old/internode.json
+++ b/components_old/internode.json
@@ -1,6 +1,0 @@
-{
-  "name": "internode",
-  "owner": ["@LeighCurran"],
-  "manifest": "https://raw.githubusercontent.com/LeighCurran/InternodeHA/main/custom_components/internode/manifest.json",
-  "url": "https://github.com/LeighCurran/InternodeHA"
-}

--- a/components_old/iparcelbox.json
+++ b/components_old/iparcelbox.json
@@ -1,6 +1,0 @@
-{	
-  "name": "iParcelBox",	
-  "owner": ["@gadget-man"],	
-  "manifest": "https://raw.githubusercontent.com/gadget-man/iparcelboxHA/main/manifest.json",	
-  "url": "https://github.com/gadget-man/iparcelboxHA"	
-}

--- a/components_old/ipx800v4.json
+++ b/components_old/ipx800v4.json
@@ -1,6 +1,0 @@
-{
-    "name": "GCE IPX800V4",
-    "owner": ["@Aohzan"],
-    "manifest": "https://raw.githubusercontent.com/Aohzan/ipx800/master/custom_components/ipx800v4/manifest.json",
-    "url": "https://github.com/Aohzan/ipx800"
-}

--- a/components_old/ipx800v5.json
+++ b/components_old/ipx800v5.json
@@ -1,6 +1,0 @@
-{
-    "name": "GCE IPX800V5",
-    "owner": ["@Aohzan"],
-    "manifest": "https://raw.githubusercontent.com/Aohzan/ipx800v5/master/custom_components/ipx800v5/manifest.json",
-    "url": "https://github.com/Aohzan/ipx800v5"
-}

--- a/components_old/jellyfin.json
+++ b/components_old/jellyfin.json
@@ -1,6 +1,0 @@
-{
-    "name": "Jellyfin",
-    "owner": ["@koying"],
-    "manifest": "https://raw.githubusercontent.com/koying/jellyfin_ha/main/custom_components/jellyfin/manifest.json",
-    "url": "https://github.com/koying/jellyfin_ha"
-}

--- a/components_old/jq300.json
+++ b/components_old/jq300.json
@@ -1,6 +1,0 @@
-{
-  "name": "JQ-300/200/100 Indoor Air Quality Meter",
-  "owner": ["@Limych"],
-  "manifest": "https://raw.githubusercontent.com/Limych/ha-jq300/dev/custom_components/jq300/manifest.json",
-  "url": "https://github.com/Limych/ha-jq300"
-}

--- a/components_old/jumbo.json
+++ b/components_old/jumbo.json
@@ -1,6 +1,0 @@
-{
-  "name": "Jumbo",
-  "owner": ["@peternijssen"],
-  "manifest": "https://raw.githubusercontent.com/peternijssen/home-assistant-jumbo/master/custom_components/jumbo/manifest.json",
-  "url": "https://github.com/peternijssen/home-assistant-jumbo"
-}

--- a/components_old/kamstrup_403.json
+++ b/components_old/kamstrup_403.json
@@ -1,6 +1,0 @@
-{
-  "name": "Kamstrup 403",
-  "owner": ["@golles"],
-  "manifest": "https://raw.githubusercontent.com/golles/ha-kamstrup_403/main/custom_components/kamstrup_403/manifest.json",
-  "url": "https://github.com/golles/ha-kamstrup_403"
-}

--- a/components_old/kef_connector.json
+++ b/components_old/kef_connector.json
@@ -1,6 +1,0 @@
-{
-  "name": "Kef Connector",
-  "owner": ["@n0ciple"],
-  "manifest": "https://raw.githubusercontent.com/N0ciple/hass-kef-connector/main/custom_components/kef_connector/manifest.json",
-  "url": "https://github.com/N0ciple/hass-kef-connector"
-}

--- a/components_old/kia_uvo.json
+++ b/components_old/kia_uvo.json
@@ -1,6 +1,0 @@
-{
-    "name": "Kia UVO / Hyundai Bluelink",
-    "owner": ["@fuatakgun"],
-    "manifest": "https://raw.githubusercontent.com/fuatakgun/kia_uvo/master/custom_components/kia_uvo/manifest.json",
-    "url": "https://github.com/fuatakgun/kia_uvo"
-}

--- a/components_old/lamarzocco.json
+++ b/components_old/lamarzocco.json
@@ -1,6 +1,0 @@
-{
-    "name": "lamarzocco",
-    "owner": ["@rccoleman"],
-    "manifest": "https://raw.githubusercontent.com/rccoleman/lamarzocco/master/custom_components/lamarzocco/manifest.json",
-    "url": "https://github.com/rccoleman/lamarzocco"
-}

--- a/components_old/libratone_zipp.json
+++ b/components_old/libratone_zipp.json
@@ -1,6 +1,0 @@
-{
-  "name": "Libratone Zipp",
-  "owner": ["@chouffy"],
-  "manifest": "https://raw.githubusercontent.com/Chouffy/home_assistant_libratone_zipp/master/custom_components/libratone_zipp/manifest.json",
-  "url": "https://github.com/Chouffy/home_assistant_libratone_zipp"
-}

--- a/components_old/lightwave2.json
+++ b/components_old/lightwave2.json
@@ -1,6 +1,0 @@
-{
-  "name": "lightwave2",
-  "owner": ["@bigbadblunt"],
-  "manifest": "https://raw.githubusercontent.com/bigbadblunt/homeassistant-lightwave2/master/custom_components/lightwave2/manifest.json",
-  "url": "https://github.com/bigbadblunt/homeassistant-lightwave2"
-}

--- a/components_old/linkplay.json
+++ b/components_old/linkplay.json
@@ -1,6 +1,0 @@
-{
-  "name": "LinkPlay devices",
-  "owner": ["@nicjo814", "@nagyrobi"],
-  "manifest": "https://raw.githubusercontent.com/nagyrobi/home-assistant-custom-components-linkplay/master/custom_components/linkplay/manifest.json",
-  "url": "https://github.com/nagyrobi/home-assistant-custom-components-linkplay"
-}

--- a/components_old/litetouch.json
+++ b/components_old/litetouch.json
@@ -1,6 +1,0 @@
-{
-    "name": "LiteTouch",
-    "owner": ["@patmann03"],
-    "manifest": "https://raw.githubusercontent.com/patmann03/custom_components/master/custom_components/litetouch/manifest.json",
-    "url": "https://github.com/patmann03/custom_components/tree/master/custom_components/litetouch"
-}

--- a/components_old/litterrobot.json
+++ b/components_old/litterrobot.json
@@ -1,6 +1,0 @@
-{
-    "name": "Litter-Robot Connect",
-    "owner": ["@natekspencer"],
-    "manifest": "https://raw.githubusercontent.com/natekspencer/hacs-litterrobot/main/custom_components/litterrobot/manifest.json",
-    "url": "https://github.com/natekspencer/hacs-litterrobot"
-}

--- a/components_old/livebox.json
+++ b/components_old/livebox.json
@@ -1,7 +1,0 @@
-
-{
-  "name": "Orange Livebox",
-  "owner": ["@cyr-ius"],
-  "manifest": "https://raw.githubusercontent.com/cyr-ius/hass-livebox-component/master/custom_components/livebox/manifest.json",
-  "url": "https://github.com/cyr-ius/hass-livebox-component"
-}

--- a/components_old/lkcomu_interrao.json
+++ b/components_old/lkcomu_interrao.json
@@ -1,6 +1,0 @@
-{
-  "name": "Inter RAO Personal Cabinet",
-  "owner": ["@alryaz"],
-  "manifest": "https://raw.githubusercontent.com/alryaz/hass-lkcomu-interrao/main/custom_components/lkcomu_interrao/manifest.json",
-  "url": "https://github.com/alryaz/hass-lkcomu-interrao"
-}

--- a/components_old/lobe.json
+++ b/components_old/lobe.json
@@ -1,6 +1,0 @@
-{
-  "name": "Lobe",
-  "owner": ["@KTibow"],
-  "manifest": "https://raw.githubusercontent.com/KTibow/lobe-home-assistant/main/custom_components/lobe/manifest.json",
-  "url": "https://github.com/KTibow/lobe-home-assistant"
-}

--- a/components_old/loxone.json
+++ b/components_old/loxone.json
@@ -1,6 +1,0 @@
-{
-  "name": "PyLoxone",
-  "owner": ["@JoDehli"],
-  "manifest": "https://raw.githubusercontent.com/JoDehli/PyLoxone/master/custom_components/loxone/manifest.json",
-  "url": "https://github.com/JoDehli/PyLoxone"
-}

--- a/components_old/ltss.json
+++ b/components_old/ltss.json
@@ -1,6 +1,0 @@
-{
-    "name": "LTSS",
-    "owner": ["@freol35241"],
-    "manifest": "https://raw.githubusercontent.com/freol35241/ltss/master/custom_components/ltss/manifest.json",
-    "url": "https://github.com/freol35241/ltss"
-}

--- a/components_old/luxtronik.json
+++ b/components_old/luxtronik.json
@@ -1,6 +1,0 @@
-{
-  "name": "Luxtronik",
-  "owner": ["@bouni"],
-  "manifest": "https://raw.githubusercontent.com/Bouni/luxtronik/master/custom_components/luxtronik/manifest.json",
-  "url": "https://github.com/Bouni/luxtronik"
-}

--- a/components_old/lyric.json
+++ b/components_old/lyric.json
@@ -1,6 +1,0 @@
-{
-  "name": "lyric",
-  "owner": ["@bramkragten"],
-  "manifest": "https://raw.githubusercontent.com/bramkragten/lyric/master/custom_components/lyric/manifest.json",
-  "url": "https://github.com/bramkragten/lyric"
-}

--- a/components_old/magicswitchbot.json
+++ b/components_old/magicswitchbot.json
@@ -1,6 +1,0 @@
-{
-  "name": "Magic Switchbot",
-  "owner": ["@ec-blaster"],
-  "manifest": "https://raw.githubusercontent.com/ec-blaster/magicswitchbot-homeassistant/main/custom_components/magicswitchbot/manifest.json",
-  "url": "https://github.com/ec-blaster/magicswitchbot-homeassistant"
-}

--- a/components_old/mail_and_packages.json
+++ b/components_old/mail_and_packages.json
@@ -1,7 +1,0 @@
-{
-    "name": "mail_and_packages",
-    "owner": ["@moralmunky", "@firstof9"],
-    "manifest": "https://raw.githubusercontent.com/moralmunky/Home-Assistant-Mail-And-Packages/master/custom_components/mail_and_packages/manifest.json",
-    "url": "https://github.com/moralmunky/Home-Assistant-Mail-And-Packages"
-  }
-  

--- a/components_old/mbapi2020.json
+++ b/components_old/mbapi2020.json
@@ -1,6 +1,0 @@
-{
-  "name": "mbapi2020",
-  "owner": ["@ReneNulschDE"],
-  "manifest": "https://raw.githubusercontent.com/ReneNulschDE/mbapi2020/master/custom_components/mbapi2020/manifest.json",
-  "url": "https://github.com/ReneNulschDE/mbapi2020" 
-}

--- a/components_old/mcp23017.json
+++ b/components_old/mcp23017.json
@@ -1,6 +1,0 @@
-{
-    "name": "mcp23017",
-    "owner": ["@jpcornil-git"],
-    "manifest": "https://raw.githubusercontent.com/jpcornil-git/HA-mcp23017/master/custom_components/mcp23017/manifest.json",
-    "url": "https://github.com/jpcornil-git/HA-mcp23017"
-}

--- a/components_old/mdadm_state.json
+++ b/components_old/mdadm_state.json
@@ -1,6 +1,0 @@
-{
-  "name": "RAID Status - MDADM",
-  "owner": ["@LorenzoVasi"],
-  "manifest": "https://raw.githubusercontent.com/LorenzoVasi/HA_mdadm/main/custom_components/mdadm_state/manifest.json",
-  "url": "https://github.com/LorenzoVasi/HA_mdadm"
-}

--- a/components_old/meteoalarmeu.json
+++ b/components_old/meteoalarmeu.json
@@ -1,6 +1,0 @@
-{
-  "name": "meteoalarmeu",
-  "owner": ["@xlcnd"],
-  "manifest": "https://raw.githubusercontent.com/xlcnd/meteoalarmeu/main/custom_components/meteoalarmeu/manifest.json",
-  "url": "https://github.com/xlcnd/meteoalarmeu"
-}

--- a/components_old/meteobridge.json
+++ b/components_old/meteobridge.json
@@ -1,6 +1,0 @@
-{
-    "name": "meteobridge",
-    "owner": ["@briis"],
-    "manifest": "https://raw.githubusercontent.com/briis/meteobridge/master/custom_components/meteobridge/manifest.json",
-    "url": "https://github.com/briis/meteobridge"
-}

--- a/components_old/metlink.json
+++ b/components_old/metlink.json
@@ -1,6 +1,0 @@
-{
-    "name": "Metlink Wellington Transport",
-    "owner": ["@make-all"],
-    "manifest": "https://raw.githubusercontent.com/make-all/metlink-nz/main/custom_components/metlink/manifest.json",
-    "url": "https://github.com/make-all/metlink-nz"
-}

--- a/components_old/midea_ac_lan.json
+++ b/components_old/midea_ac_lan.json
@@ -1,6 +1,0 @@
-{
-  "name": "Midea AC on LAN",
-  "owner": ["@wyapx"],
-  "manifest": "https://raw.githubusercontent.com/wyapx/hass_midea_acc/master/custom_components/midea_ac_lan/manifest.json",
-  "url": "https://github.com/wyapx/hass_midea_acc"
-}

--- a/components_old/midea_dehumidifier.json
+++ b/components_old/midea_dehumidifier.json
@@ -1,6 +1,0 @@
-{
-  "name": "EVA II PRO WiFi Midea Inventor Dehumidifier custom integration",
-  "owner": ["@barban-dev"],
-  "manifest": "https://raw.githubusercontent.com/barban-dev/homeassistant-midea-dehumidifier/master/custom_components/midea_dehumidifier/manifest.json",
-  "url": "https://github.com/barban-dev/homeassistant-midea-dehumidifier"
-}

--- a/components_old/miele.json
+++ b/components_old/miele.json
@@ -1,6 +1,0 @@
-{
-    "name": "miele",
-    "owner": ["@kloknibor"],
-    "manifest": "https://raw.githubusercontent.com/HomeAssistant-Mods/home-assistant-miele/master/custom_components/miele/manifest.json",
-    "url": "https://github.com/HomeAssistant-Mods/home-assistant-miele"
-}

--- a/components_old/miio_yeelink.json
+++ b/components_old/miio_yeelink.json
@@ -1,6 +1,0 @@
-{
-  "name": "miio_yeelink",
-  "owner": ["@al-one"],
-  "manifest": "https://raw.githubusercontent.com/al-one/hass-miio-yeelink/master/custom_components/miio_yeelink/manifest.json",
-  "url": "https://github.com/al-one/hass-miio-yeelink"
-}

--- a/components_old/mikrotik_api.json
+++ b/components_old/mikrotik_api.json
@@ -1,6 +1,0 @@
-{
-  "name": "Mikrotik API",
-  "owner": ["@pilotak"],
-  "manifest": "https://raw.githubusercontent.com/pilotak/homeassistant-mikrotik-api/master/custom_components/mikrotik_api/manifest.json",
-  "url": "https://github.com/pilotak/homeassistant-mikrotik-api"
-}

--- a/components_old/mikrotik_router.json
+++ b/components_old/mikrotik_router.json
@@ -1,6 +1,0 @@
-{
-  "name": "Mikrotik Router",
-  "owner": ["@tomaae"],
-  "manifest": "https://raw.githubusercontent.com/tomaae/homeassistant-mikrotik_router/master/custom_components/mikrotik_router/manifest.json",
-  "url": "https://github.com/tomaae/homeassistant-mikrotik_router"
-}

--- a/components_old/mintmobile.json
+++ b/components_old/mintmobile.json
@@ -1,6 +1,0 @@
-{
-    "name": "Mint Mobile",
-    "owner": ["@ryanmac8"],
-    "manifest": "https://raw.githubusercontent.com/ryanmac8/HA-Mint-Mobile/master/custom_components/mintmobile/manifest.json",
-    "url": "https://github.com/ryanmac8/HA-Mint-Mobile"
-}

--- a/components_old/mitemp_bt2.json
+++ b/components_old/mitemp_bt2.json
@@ -1,6 +1,0 @@
-{
-  "name": "Xiaomi Mijia BLE Temperature Hygrometer 2",
-  "owner": ["@leonxi"],
-  "manifest": "https://raw.githubusercontent.com/leonxi/mitemp_bt2/main/custom_components/mitemp_bt2/manifest.json",
-  "url": "https://github.com/leonxi/mitemp_bt2"
-}

--- a/components_old/moat_temp_hum_ble.json
+++ b/components_old/moat_temp_hum_ble.json
@@ -1,6 +1,0 @@
-{
-  "name": "Moat Temperature/Humidity BLE Sensors",
-  "owner": ["@SteveOnorato"],
-  "manifest": "https://raw.githubusercontent.com/SteveOnorato/moat_temp_hum_ble/master/custom_components/moat_temp_hum_ble/manifest.json",
-  "url": "https://github.com/SteveOnorato/moat_temp_hum_ble"
-}

--- a/components_old/monitor_docker.json
+++ b/components_old/monitor_docker.json
@@ -1,6 +1,0 @@
-{
-  "name": "Monitor Docker",
-  "owner": ["@ualex73"],
-  "manifest": "https://raw.githubusercontent.com/ualex73/monitor_docker/master/custom_components/monitor_docker/manifest.json",
-  "url": "https://github.com/ualex73/monitor_docker"
-}

--- a/components_old/moox_track.json
+++ b/components_old/moox_track.json
@@ -1,6 +1,0 @@
-{
-  "name": "MOOX Track",
-  "owner": ["@moox-it"],
-  "manifest": "https://raw.githubusercontent.com/moox-it/hass-moox-track/master/custom_components/moox_track/manifest.json",
-  "url": "https://github.com/moox-it/hass-moox-track"
-}

--- a/components_old/morph_numbers.json
+++ b/components_old/morph_numbers.json
@@ -1,6 +1,0 @@
-{
-  "name": "Morph Numbers",
-  "owner": ["@AlexxIT"],
-  "manifest": "https://raw.githubusercontent.com/AlexxIT/MorphNumbers/master/custom_components/morph_numbers/manifest.json",
-  "url": "https://github.com/AlexxIT/MorphNumbers"
-}

--- a/components_old/mosenergosbyt.json
+++ b/components_old/mosenergosbyt.json
@@ -1,6 +1,0 @@
-{
-  "name": "Mosenergosbyt",
-  "owner": ["@alryaz"],
-  "manifest": "https://raw.githubusercontent.com/alryaz/hass-mosenergosbyt/master/custom_components/mosenergosbyt/manifest.json",
-  "url": "https://github.com/alryaz/hass-mosenergosbyt"
-}

--- a/components_old/mosoblgaz.json
+++ b/components_old/mosoblgaz.json
@@ -1,6 +1,0 @@
-{
-  "name": "Mosoblgaz",
-  "owner": ["@alryaz"],
-  "manifest": "https://raw.githubusercontent.com/alryaz/hass-mosoblgaz/master/custom_components/mosoblgaz/manifest.json",
-  "url": "https://github.com/alryaz/hass-mosoblgaz"
-}

--- a/components_old/motioneye.json
+++ b/components_old/motioneye.json
@@ -1,6 +1,0 @@
-{
-    "name": "motionEye",
-    "owner": ["@dermotduffy"],
-    "manifest": "https://raw.githubusercontent.com/dermotduffy/hass-motioneye/master/custom_components/motioneye/manifest.json",
-    "url": "https://github.com/dermotduffy/hass-motioneye"
-}

--- a/components_old/multimatic.json
+++ b/components_old/multimatic.json
@@ -1,8 +1,0 @@
-{
-  "name": "Multimatic",
-  "owner": [
-    "@thomasgermain"
-  ],
-  "manifest": "https://raw.githubusercontent.com/thomasgermain/vaillant-component/master/custom_components/multimatic/manifest.json",
-  "url": "https://github.com/thomasgermain/vaillant-component"
-}

--- a/components_old/multiscrape.json
+++ b/components_old/multiscrape.json
@@ -1,6 +1,0 @@
-{
-  "name": "HA Multiscrape",
-  "owner": ["@danieldotnl"],
-  "manifest": "https://raw.githubusercontent.com/danieldotnl/ha-multiscrape/master/custom_components/multiscrape/manifest.json",
-  "url": "https://github.com/danieldotnl/ha-multiscrape"
-}

--- a/components_old/multizone_thermostat.json
+++ b/components_old/multizone_thermostat.json
@@ -1,6 +1,0 @@
-{
-    "name": "MultiZone thermostat",
-    "owner": ["@vindaalex"],
-    "manifest": "https://raw.githubusercontent.com/vindaalex/multizone-thermostat/master/custom_components/multizone_thermostat/manifest.json",
-    "url": "https://github.com/vindaalex/multizone-thermostat"
-  }

--- a/components_old/musiccast_yamaha.json
+++ b/components_old/musiccast_yamaha.json
@@ -1,6 +1,0 @@
-{
-  "name": "musiccast_yamaha",
-  "owner": ["@ppanagiotis"],
-  "manifest": "https://raw.githubusercontent.com/ppanagiotis/pymusiccast/master/custom_components/musiccast_yamaha/manifest.json",
-  "url": "https://github.com/ppanagiotis/pymusiccast"
-}

--- a/components_old/myenergi.json
+++ b/components_old/myenergi.json
@@ -1,6 +1,0 @@
-{
-  "name": "myenergi",
-  "owner": ["@CJNE"],
-  "manifest": "https://raw.githubusercontent.com/CJNE/ha-myenergi/main/custom_components/myenergi/manifest.json",
-  "url": "https://github.com/CJNE/ha-myenergi"
-}

--- a/components_old/myq.json
+++ b/components_old/myq.json
@@ -1,6 +1,0 @@
-{
-  "name": "myQ",
-  "owner": ["@ehendrix23"],
-  "manifest": "https://raw.githubusercontent.com/ehendrix23/hass_myq/master/custom_components/myq/manifest.json",
-  "url": "https://github.com/ehendrix23/hass_myq"
-}

--- a/components_old/nespresso.json
+++ b/components_old/nespresso.json
@@ -1,6 +1,0 @@
-{
-  "name": "Nespresso BLE coffee machine",
-  "owner": ["@tikismoke"],
-  "manifest": "https://raw.githubusercontent.com/tikismoke/home-assistant-nespressoble/master/custom_components/nespresso/manifest.json",
-  "url": "https://github.com/tikismoke/home-assistant-nespressoble"
-}

--- a/components_old/netia_player.json
+++ b/components_old/netia_player.json
@@ -1,6 +1,0 @@
-{
-  "name": "Netia Player",
-  "owner": ["@korasinski"],
-  "manifest": "https://raw.githubusercontent.com/korasinski/ha-netia/master/custom_components/netia_player/manifest.json",
-  "url": "https://github.com/korasinski/ha-netia"
-}

--- a/components_old/ngenic.json
+++ b/components_old/ngenic.json
@@ -1,6 +1,0 @@
-{
-    "name": "ngenic",
-    "owner": ["@sfalkman"],
-    "manifest": "https://raw.githubusercontent.com/sfalkman/ngenic-hass-platform/master/custom_components/ngenic/manifest.json",
-    "url": "https://github.com/sfalkman/ngenic-hass-platform"
-}

--- a/components_old/nhc2.json
+++ b/components_old/nhc2.json
@@ -1,6 +1,0 @@
-{
-  "name": "nhc2",
-  "owner": ["@filipvh"],
-  "manifest": "https://raw.githubusercontent.com/filipvh/hass-nhc2/master/custom_components/nhc2/manifest.json",
-  "url": "https://github.com/filipvh/hass-nhc2"
-}

--- a/components_old/nobo_hub.json
+++ b/components_old/nobo_hub.json
@@ -1,6 +1,0 @@
-{
-  "name": "nobo_hub",
-  "owner": ["@echoromeo"],
-  "manifest": "https://raw.githubusercontent.com/echoromeo/hanobo/master/custom_components/nobo_hub/manifest.json",
-  "url": "https://github.com/echoromeo/hanobo"
-}

--- a/components_old/nordigen.json
+++ b/components_old/nordigen.json
@@ -1,6 +1,0 @@
-{
-    "name": "Nordigen",
-    "owner": ["@dogmatic69"],
-    "manifest": "https://raw.githubusercontent.com/dogmatic69/nordigen-homeassistant/master/manifest.json",
-    "url": "https://github.com/dogmatic69/nordigen-homeassistant"
-}

--- a/components_old/nordpool.json
+++ b/components_old/nordpool.json
@@ -1,6 +1,0 @@
-{
-  "name": "nordpool",
-  "owner": ["@Hellowlol"],
-  "manifest": "https://raw.githubusercontent.com/custom-components/nordpool/master/custom_components/nordpool/manifest.json",
-  "url": "https://github.com/custom-components/nordpool/"
-}

--- a/components_old/nosnews.json
+++ b/components_old/nosnews.json
@@ -1,6 +1,0 @@
-{
-    "name": "NosNews",
-    "owner": ["@eelcob"],
-    "manifest": "https://raw.githubusercontent.com/eelcob/nosnews/master/custom_components/nosnews/manifest.json",
-    "url": "https://github.com/eelcob/nosnews"
-}

--- a/components_old/novus300bus.json
+++ b/components_old/novus300bus.json
@@ -1,6 +1,0 @@
-{
-  "name": "Paul Novus 300 RS-485 Bus",
-  "owner": ["@BenPru"],
-  "manifest": "https://raw.githubusercontent.com/BenPru/novus300_Rs485/main/custom_components/novus300bus/manifest.json",
-  "url": "https://github.com/BenPru/novus300_Rs485"
-}

--- a/components_old/nsw_rural_fire_service_fire_danger.json
+++ b/components_old/nsw_rural_fire_service_fire_danger.json
@@ -1,6 +1,0 @@
-{
-  "name": "NSW Rural Fire Service - Fire Danger",
-  "owner": ["@exxamalte"],
-  "manifest": "https://raw.githubusercontent.com/exxamalte/home-assistant-custom-components-nsw-rural-fire-service-fire-danger/main/custom_components/nsw_rural_fire_service_fire_danger/manifest.json",
-  "url": "https://github.com/exxamalte/home-assistant-custom-components-nsw-rural-fire-service-fire-danger"
-}

--- a/components_old/nswcovid.json
+++ b/components_old/nswcovid.json
@@ -1,8 +1,0 @@
-{
-    "name": "NSW Covid",
-    "owner": [
-        "@troykelly"
-    ],
-    "manifest": "https://raw.githubusercontent.com/troykelly/homeassistant-au-nsw-covid/main/custom_components/nswcovid/manifest.json",
-    "url": "https://github.com/troykelly/homeassistant-au-nsw-covid"
-}

--- a/components_old/nuvo_serial.json
+++ b/components_old/nuvo_serial.json
@@ -1,6 +1,0 @@
-{
-  "name": "nuvo_serial",
-  "owner": ["@sprocket-9"],
-  "manifest": "https://raw.githubusercontent.com/sprocket-9/hacs-nuvo-serial/main/custom_components/nuvo_serial/manifest.json",
-  "url": "https://github.com/sprocket-9/hacs-nuvo-serial"
-}

--- a/components_old/nyc311.json
+++ b/components_old/nyc311.json
@@ -1,6 +1,0 @@
-{
-    "name": "NYC 311 Public Services Calendar",
-    "owner": ["@elahd"],
-    "manifest": "https://raw.githubusercontent.com/elahd/ha-nyc311/main/custom_components/nyc311/manifest.json",
-    "url": "https://github.com/elahd/ha-nyc311"
-  }

--- a/components_old/o365.json
+++ b/components_old/o365.json
@@ -1,6 +1,0 @@
-{
-  "name": "o365",
-  "owner": ["@rogerselwyn"],
-  "manifest": "https://raw.githubusercontent.com/RogerSelwyn/O365-HomeAssistant/master/custom_components/o365/manifest.json",
-  "url": "https://github.com/RogerSelwyn/O365-HomeAssistant"
-}

--- a/components_old/ocpp.json
+++ b/components_old/ocpp.json
@@ -1,6 +1,0 @@
-{
-  "name": "Open Charge Point Protocol (OCPP)",
-  "owner": ["@lbbrhzn"],
-  "manifest": "https://raw.githubusercontent.com/lbbrhzn/ocpp/main/custom_components/ocpp/manifest.json",
-  "url": "https://github.com/lbbrhzn/ocpp"
-}

--- a/components_old/omnik_inverter.json
+++ b/components_old/omnik_inverter.json
@@ -1,6 +1,0 @@
-{
-    "name": "Omnik Inverter",
-    "owner": ["@klaasnicolaas","@robbinjanssen"],
-    "manifest": "https://raw.githubusercontent.com/robbinjanssen/home-assistant-omnik-inverter/master/custom_components/omnik_inverter/manifest.json",
-    "url": "https://github.com/robbinjanssen/home-assistant-omnik-inverter"
-}

--- a/components_old/open_route_service.json
+++ b/components_old/open_route_service.json
@@ -1,6 +1,0 @@
-{
-  "name": "open_route_service",
-  "owner": ["@eifinger"],
-  "manifest": "https://raw.githubusercontent.com/eifinger/open_route_service/master/custom_components/open_route_service/manifest.json",
-  "url": "https://github.com/eifinger/open_route_service"
-}

--- a/components_old/openei.json
+++ b/components_old/openei.json
@@ -1,6 +1,0 @@
-{
-    "name": "OpenEI",
-    "owner": ["@firstof9"],
-    "manifest": "https://raw.githubusercontent.com/firstof9/ha-openei/master/custom_components/openei/manifest.json",
-    "url": "https://github.com/firstof9/ha-openei"
-  }

--- a/components_old/openhab.json
+++ b/components_old/openhab.json
@@ -1,6 +1,0 @@
-{
-  "name": "openHAB",
-  "owner": ["@kubawolanin"],
-  "manifest": "https://raw.githubusercontent.com/kubawolanin/ha-openhab/master/custom_components/openhab/manifest.json",
-  "url": "https://github.com/kubawolanin/ha-openhab"
-}

--- a/components_old/openhasp.json
+++ b/components_old/openhasp.json
@@ -1,8 +1,0 @@
-{
-  "name": "openHASP",
-  "owner": [
-    "@dgomes"
-  ],
-  "manifest": "https://raw.githubusercontent.com/HASwitchPlate/openHASP-custom-component/main/custom_components/openhasp/manifest.json",
-  "url": "https://github.com/HASwitchPlate/openHASP-custom-component/"
-}

--- a/components_old/openrgb.json
+++ b/components_old/openrgb.json
@@ -1,6 +1,0 @@
-{
-    "name": "OpenRGB",
-    "owner": ["@bahorn", "@koying"],
-    "manifest": "https://raw.githubusercontent.com/koying/openrgb_ha/master/custom_components/openrgb/manifest.json",
-    "url": "https://github.com/koying/openrgb_ha"
-}

--- a/components_old/opensprinkler.json
+++ b/components_old/opensprinkler.json
@@ -1,6 +1,0 @@
-{
-  "name": "OpenSprinkler",
-  "owner": ["@vinteo"],
-  "manifest": "https://raw.githubusercontent.com/vinteo/hass-opensprinkler/master/custom_components/opensprinkler/manifest.json",
-  "url": "https://github.com/vinteo/hass-opensprinkler"
-}

--- a/components_old/openweathermap_all.json
+++ b/components_old/openweathermap_all.json
@@ -1,6 +1,0 @@
-{
-    "name": "OpenWeatherMap All",
-    "owner": ["@viktak"],
-    "manifest": "https://raw.githubusercontent.com/viktak/ha-cc-openweathermap_all/main/custom_components/openweathermap_all/manifest.json",
-    "url": "https://github.com/viktak/ha-cc-openweathermap_all"
-}

--- a/components_old/oppo_udp.json
+++ b/components_old/oppo_udp.json
@@ -1,6 +1,0 @@
-{
-  "name": "Oppo UDP-20x",
-  "owner": ["@simbaja"],
-  "manifest": "https://raw.githubusercontent.com/simbaja/ha_oppoudp/master/custom_components/oppo_udp/manifest.json",
-  "url": "https://github.com/simbaja/ha_oppoudp/tree/master/custom_components/oppo_udp"
-}

--- a/components_old/optus.json
+++ b/components_old/optus.json
@@ -1,6 +1,0 @@
-{
-  "name": "optus",
-  "owner": ["@itchannel"],
-  "manifest": "https://raw.githubusercontent.com/itchannel/optus-ha/master/custom_components/optus/manifest.json",
-  "url": "https://github.com/itchannel/optus-ha"
-}

--- a/components_old/osrm_travel_time.json
+++ b/components_old/osrm_travel_time.json
@@ -1,6 +1,0 @@
-{
-  "name": "osrm_travel_time",
-  "owner": ["@edekeijzer"],
-  "manifest": "https://raw.githubusercontent.com/edekeijzer/osrm_travel_time/master/custom_components/osrm_travel_time/manifest.json",
-  "url": "https://github.com/edekeijzer/osrm_travel_time"
-}

--- a/components_old/palazzetti.json
+++ b/components_old/palazzetti.json
@@ -1,6 +1,0 @@
-{
-    "name": "Palazzetti",
-    "owner": ["@marcopal74"],
-    "manifest": "https://raw.githubusercontent.com/marcopal74/home-assistant-palazzetti/master/custom_components/palazzetti/manifest.json",
-    "url": "https://github.com/marcopal74/home-assistant-palazzetti"
-}

--- a/components_old/panasonic_cc.json
+++ b/components_old/panasonic_cc.json
@@ -1,6 +1,0 @@
-{
-    "name": "Panasonic Comfort Cloud",
-    "owner": ["@sockless-coding"],
-    "manifest": "https://raw.githubusercontent.com/sockless-coding/panasonic_cc/master/custom_components/panasonic_cc/manifest.json",
-    "url": "https://github.com/sockless-coding/panasonic_cc"
-}

--- a/components_old/peloton.json
+++ b/components_old/peloton.json
@@ -1,6 +1,0 @@
-{
-  "name": "Peloton",
-  "owner": ["@edwork"],
-  "manifest": "https://raw.githubusercontent.com/edwork/homeassistant-peloton-sensor/master/custom_components/peloton/manifest.json",
-  "url": "https://github.com/edwork/homeassistant-peloton-sensor"
-}

--- a/components_old/pfsense.json
+++ b/components_old/pfsense.json
@@ -1,6 +1,0 @@
-{
-  "name": "hacs",
-  "owner": ["@travisghansen"],
-  "manifest": "https://raw.githubusercontent.com/travisghansen/hass-pfsense/main/custom_components/pfsense/manifest.json",
-  "url": "https://github.com/travisghansen/hass-pfsense"
-}

--- a/components_old/phoenix_ev_charger.json
+++ b/components_old/phoenix_ev_charger.json
@@ -1,6 +1,0 @@
-{
-  "name": "Phoenix EV Charger",
-  "owner": ["@abrlox"],
-  "manifest": "https://raw.githubusercontent.com/abrlox/home-assistant-phoenix-ev-charger/main/custom_components/phoenix_ev_charger/manifest.json",
-  "url": "https://github.com/abrlox/home-assistant-phoenix-ev-charger"
-}

--- a/components_old/pijuice.json
+++ b/components_old/pijuice.json
@@ -1,6 +1,0 @@
-{
-  "name": "PiJuice UPS HAT",
-  "owner": ["@racailloux"],
-  "manifest": "https://raw.githubusercontent.com/Racailloux/home-assistant-pijuice/main/custom_components/pijuice/manifest.json",
-  "url": "https://github.com/Racailloux/home-assistant-pijuice"
-}

--- a/components_old/pioneer_async.json
+++ b/components_old/pioneer_async.json
@@ -1,7 +1,0 @@
-
-{
-  "name": "Pioneer AVR (async)",
-  "owner": ["@crowbarz"],
-  "manifest": "https://raw.githubusercontent.com/crowbarz/ha-pioneer_async/master/custom_components/pioneer_async/manifest.json",
-  "url": "https://github.com/crowbarz/ha-pioneer_async"
-}

--- a/components_old/pirateweather.json
+++ b/components_old/pirateweather.json
@@ -1,6 +1,0 @@
-{
-  "name": "PirateWeather",
-  "owner": ["@alexander0042"],
-  "manifest": "https://raw.githubusercontent.com/alexander0042/pirate-weather-ha/master/custom_components/pirateweather/manifest.json",
-  "url": "https://github.com/alexander0042/pirate-weather-ha"
-}

--- a/components_old/plcbus.json
+++ b/components_old/plcbus.json
@@ -1,6 +1,0 @@
-{
-  "name": "PLCBus",
-  "owner": ["@tikismoke"],
-  "manifest": "https://raw.githubusercontent.com/tikismoke/home-assistant-plcbus/master/custom_components/plcbus/manifest.json",
-  "url": "https://github.com/tikismoke/home-assistant-plcbus"
-}

--- a/components_old/plex_assistant.json
+++ b/components_old/plex_assistant.json
@@ -1,6 +1,0 @@
-{
-  "name": "plex_assistant",
-  "owner": ["@maykar"],
-  "manifest": "https://raw.githubusercontent.com/maykar/plex_assistant/master/custom_components/plex_assistant/manifest.json",
-  "url": "https://github.com/maykar/plex_assistant"
-}

--- a/components_old/plugwise_stick.json
+++ b/components_old/plugwise_stick.json
@@ -1,6 +1,0 @@
-{
-    "name": "Plugwise USB-stick",
-    "owner": ["@brefra"],
-    "manifest": "https://raw.githubusercontent.com/brefra/home-assistant-plugwise-stick/master/custom_components/plugwise_stick/manifest.json",
-    "url": "https://github.com/brefra/home-assistant-plugwise-stick"
-}

--- a/components_old/poolmath.json
+++ b/components_old/poolmath.json
@@ -1,6 +1,0 @@
-{
-  "name": "Pool Math (Trouble Free Pool)",
-  "owner": ["@rsnodgrass"],
-  "manifest": "https://raw.githubusercontent.com/rsnodgrass/hass-poolmath/master/custom_components/poolmath/manifest.json",
-  "url": "https://github.com/rsnodgrass/hass-poolmath"
-}

--- a/components_old/porscheconnect.json
+++ b/components_old/porscheconnect.json
@@ -1,6 +1,0 @@
-{
-  "name": "Porsche Connect",
-  "owner": ["@CJNE"],
-  "manifest": "https://raw.githubusercontent.com/CJNE/ha-porscheconnect/main/custom_components/porscheconnect/manifest.json",
-  "url": "https://github.com/CJNE/ha-porscheconnect"
-}

--- a/components_old/powercalc.json
+++ b/components_old/powercalc.json
@@ -1,6 +1,0 @@
-{
-  "name": "Powercalc",
-  "owner": ["@bramstroker"],
-  "manifest": "https://raw.githubusercontent.com/bramstroker/homeassistant-powercalc/master/custom_components/powercalc/manifest.json",
-  "url": "https://github.com/bramstroker/homeassistant-powercalc"
-}

--- a/components_old/powerpal.json
+++ b/components_old/powerpal.json
@@ -1,6 +1,0 @@
-{
-  "name": "powerpal",
-  "owner": ["@mindmelting"],
-  "manifest": "https://raw.githubusercontent.com/mindmelting/hass-powerpal/main/custom_components/powerpal/manifest.json",
-  "url": "https://github.com/mindmelting/hass-powerpal"
-}

--- a/components_old/pr_custom_component.json
+++ b/components_old/pr_custom_component.json
@@ -1,6 +1,0 @@
-{
-  "name": "PR Custom Component",
-  "owner": ["@alandtse"],
-  "manifest": "https://raw.githubusercontent.com/alandtse/pr_custom_component/main/custom_components/pr_custom_component/manifest.json",
-  "url": "https://github.com/alandtse/pr_custom_component"
-}

--- a/components_old/predistribuce.json
+++ b/components_old/predistribuce.json
@@ -1,6 +1,0 @@
-{
-  "name": "PRE Distribuce",
-  "owner": ["@slesinger"],
-  "manifest": "https://raw.githubusercontent.com/slesinger/HomeAssistant-PREdistribuce/master/custom_components/predistribuce/manifest.json",
-  "url": "https://github.com/slesinger/HomeAssistant-PREdistribuce"
-}

--- a/components_old/proof.json
+++ b/components_old/proof.json
@@ -1,6 +1,0 @@
-{
-  "name": "Proof Dashcam Integration",
-  "owner": ["@dimagoltsman"],
-  "manifest": "https://raw.githubusercontent.com/dimagoltsman/ha-proof-dashcam-integration/main/custom_components/proof/manifest.json",
-  "url": "https://github.com/dimagoltsman/ha-proof-dashcam-integration"
-}

--- a/components_old/proscenic.json
+++ b/components_old/proscenic.json
@@ -1,6 +1,0 @@
-{
-  "name": "proscenic 790T",
-  "owner": ["@tdeblock"],
-  "manifest": "https://raw.githubusercontent.com/deblockt/hass-proscenic-790T-vacuum/master/custom_components/proscenic/manifest.json",
-  "url": "https://github.com/deblockt/hass-proscenic-790T-vacuum"
-}

--- a/components_old/raincloud.json
+++ b/components_old/raincloud.json
@@ -1,6 +1,0 @@
-{
-  "name": "raincloud",
-  "owner": ["@vanstinator"],
-  "manifest": "https://raw.githubusercontent.com/vanstinator/hass-raincloud/master/custom_components/raincloud/manifest.json",
-  "url": "https://github.com/vanstinator/hass-raincloud"
-}

--- a/components_old/rct_power.json
+++ b/components_old/rct_power.json
@@ -1,8 +1,0 @@
-{
-  "name": "RCT Power",
-  "owner": [
-    "@weltenwort"
-  ],
-  "manifest": "https://raw.githubusercontent.com/weltenwort/home-assistant-rct-power-integration/main/custom_components/rct_power/manifest.json",
-  "url": "https://github.com/weltenwort/home-assistant-rct-power-integration"
-}

--- a/components_old/reaper.json
+++ b/components_old/reaper.json
@@ -1,6 +1,0 @@
-{
-  "name": "Reaper DAW",
-  "owner": ["@kubawolanin"],
-  "manifest": "https://raw.githubusercontent.com/kubawolanin/ha-reaper/main/custom_components/reaper/manifest.json",
-  "url": "https://github.com/kubawolanin/ha-reaper"
-}

--- a/components_old/redfin.json
+++ b/components_old/redfin.json
@@ -1,6 +1,0 @@
-{
-  "name": "redfin",
-  "owner": ["@dreed47"],
-  "manifest": "https://raw.githubusercontent.com/dreed47/redfin/main/custom_components/redfin/manifest.json",
-  "url": "https://github.com/dreed47/redfin"
-}

--- a/components_old/redpocket.json
+++ b/components_old/redpocket.json
@@ -1,6 +1,0 @@
-{
-    "name": "RedPocket Mobile",
-    "owner": ["@mbillow"],
-    "manifest": "https://raw.githubusercontent.com/mbillow/ha-redpocket/master/custom_components/ha-redpocket/manifest.json",
-    "url": "https://github.com/mbillow/ha-redpocket"
-}

--- a/components_old/renault.json
+++ b/components_old/renault.json
@@ -1,6 +1,0 @@
-{
-  "name": "Renault",
-  "owner": ["@epenet"],
-  "manifest": "https://raw.githubusercontent.com/epenet/hassRenaultZE/master/custom_components/renault/manifest.json",
-  "url": "https://github.com/epenet/hassRenaultZE"
-}

--- a/components_old/rental_control.json
+++ b/components_old/rental_control.json
@@ -1,6 +1,0 @@
-{
-  "name": "Rental Control",
-  "owner": ["@tykeal"],
-  "manifest": "https://raw.githubusercontent.com/tykeal/homeassistant-rental-control/main/custom_components/rental_control/manifest.json",
-  "url": "https://github.com/tykeal/homeassistant-rental-control"
-}

--- a/components_old/reversotts.json
+++ b/components_old/reversotts.json
@@ -1,6 +1,0 @@
-{
-  "name": "Reverso TTS",
-  "owner": ["@yuval_mejahez"],
-  "manifest": "https://raw.githubusercontent.com/rt400/ReversoTTS-HA/master/custom_components/reversotts/manifest.json",
-  "url": "https://github.com/rt400/ReversoTTS-HA"
-}

--- a/components_old/rki_covid.json
+++ b/components_old/rki_covid.json
@@ -1,6 +1,0 @@
-{
-  "name": "RKI Covid numbers",
-  "owner": ["@thebino"],
-  "manifest": "https://raw.githubusercontent.com/thebino/rki_covid/master/custom_components/rki_covid/manifest.json",
-  "url": "https://github.com/thebino/rki_covid"
-}

--- a/components_old/rocketlaunchlive.json
+++ b/components_old/rocketlaunchlive.json
@@ -1,6 +1,0 @@
-{
-  "name": "Rocket Launch Live",
-  "owner": ["@djtimca"],
-  "manifest": "https://raw.githubusercontent.com/djtimca/harocketlaunchlive/master/custom_components/rocketlaunchlive/manifest.json",
-  "url": "https://github.com/djtimca/harocketlaunchlive"
-}

--- a/components_old/rrd_recorder.json
+++ b/components_old/rrd_recorder.json
@@ -1,6 +1,0 @@
-{
-    "name": "RRD Recorder",
-    "owner": ["@dgomes"],
-    "manifest": "https://raw.githubusercontent.com/dgomes/rrd_recorder/master/custom_components/rrd/manifest.json",
-    "url": "https://github.com/dgomes/rrd_recorder/"
-}

--- a/components_old/ruuvi.json
+++ b/components_old/ruuvi.json
@@ -1,6 +1,0 @@
-{
-    "name": "Ruuvi",
-    "owner": ["@smaisidoro"],
-    "manifest": "https://raw.githubusercontent.com/ruuvi-friends/ruuvi-hass.io/master/custom_components/ruuvi/manifest.json",
-    "url": "https://github.com/ruuvi-friends/ruuvi-hass.io"
- }

--- a/components_old/s3.json
+++ b/components_old/s3.json
@@ -1,6 +1,0 @@
-{
-    "name": "S3",
-    "owner": ["@robmarkcole"],
-    "manifest": "https://raw.githubusercontent.com/robmarkcole/HASS-S3/master/custom_components/s3/manifest.json",
-    "url": "https://github.com/robmarkcole/HASS-S3"
-}

--- a/components_old/sagemcom_fast.json
+++ b/components_old/sagemcom_fast.json
@@ -1,6 +1,0 @@
-{
-    "name": "Sagemcom F@st",
-    "owner": ["@imicknl"],
-    "manifest": "https://raw.githubusercontent.com/iMicknl/ha-sagemcom-fast/master/custom_components/sagemcom_fast/manifest.json",
-    "url": "https://github.com/iMicknl/ha-sagemcom-fast"
- }

--- a/components_old/saj_modbus.json
+++ b/components_old/saj_modbus.json
@@ -1,6 +1,0 @@
-{
-  "name": "SAJ Inverter Modbus",
-  "owner": ["@wimb0"],
-  "manifest": "https://raw.githubusercontent.com/wimb0/home-assistant-saj-modbus/main/custom_components/saj_modbus/manifest.json",
-  "url": "https://github.com/wimb0/home-assistant-saj-modbus"
-}

--- a/components_old/salus.json
+++ b/components_old/salus.json
@@ -1,6 +1,0 @@
-{
-  "name": "salus",
-  "owner": ["@jvitkauskas"],
-  "manifest": "https://raw.githubusercontent.com/jvitkauskas/homeassistant_salus/master/custom_components/salus/manifest.json",
-  "url": "https://github.com/jvitkauskas/homeassistant_salus"
-}

--- a/components_old/samsungmdc.json
+++ b/components_old/samsungmdc.json
@@ -1,8 +1,0 @@
-{
-    "name": "Samsung MDC Display",
-    "owner": [
-        "@matthijs2704"
-    ],
-    "manifest": "https://raw.githubusercontent.com/matthijs2704/homeassistant-samsungmdc/main/custom_components/samsungmdc/manifest.json",
-    "url": "https://github.com/matthijs2704/homeassistant-samsungmdc"
-}

--- a/components_old/satellitetracker.json
+++ b/components_old/satellitetracker.json
@@ -1,6 +1,0 @@
-{
-  "name": "Satellite Tracker (N2YO)",
-  "owner": ["@djtimca"],
-  "manifest": "https://raw.githubusercontent.com/djtimca/hasatellitetracker/main/custom_components/satellitetracker/manifest.json",
-  "url": "https://github.com/djtimca/satellitetracker"
-}

--- a/components_old/securifi.json
+++ b/components_old/securifi.json
@@ -1,6 +1,0 @@
-{
-  "name": "securifi",
-  "owner": ["@9rpp"],
-  "manifest": "https://raw.githubusercontent.com/9rpp/securifi/master/custom_components/securifi/manifest.json",
-  "url": "https://github.com/9rpp/securifi"
-}

--- a/components_old/senec.json
+++ b/components_old/senec.json
@@ -1,6 +1,0 @@
-{
-    "name": "Senec solar system",
-    "owner": ["@mchwalisz"],
-    "manifest": "https://raw.githubusercontent.com/mchwalisz/home-assistant-senec/master/custom_components/senec/manifest.json",
-    "url": "https://github.com/mchwalisz/home-assistant-senec"
-}

--- a/components_old/senseme.json
+++ b/components_old/senseme.json
@@ -1,6 +1,0 @@
-{
-    "name": "SenseME",
-    "owner": ["@mikelawrence"],
-    "manifest": "https://raw.githubusercontent.com/mikelawrence/senseme-hacs/master/custom_components/senseme/manifest.json",
-    "url": "https://github.com/mikelawrence/senseme-hacs"
-}

--- a/components_old/sensor.stadtreinigung_hamburg.json
+++ b/components_old/sensor.stadtreinigung_hamburg.json
@@ -1,6 +1,0 @@
-{
-  "name": "Stadtreinigung Hamburg",
-  "owner": ["@vigonotion"],
-  "manifest": "https://raw.githubusercontent.com/custom-components/sensor.stadtreinigung_hamburg/master/custom_components/stadtreinigung_hamburg/manifest.json",
-  "url": "https://github.com/custom-components/sensor.stadtreinigung_hamburg"
-}

--- a/components_old/shelly.json
+++ b/components_old/shelly.json
@@ -1,6 +1,0 @@
-{
-  "name": "ShellyForHass",
-  "owner": ["@StyraHem", "@hakana"],
-  "manifest": "https://raw.githubusercontent.com/StyraHem/ShellyForHASS/master/custom_components/shelly/manifest.json",
-  "url": "https://github.com/StyraHem/ShellyForHASS"
-}

--- a/components_old/sia.json
+++ b/components_old/sia.json
@@ -1,6 +1,0 @@
-{
-  "name": "SIA",
-  "owner": ["@eavanvalkenburg"],
-  "manifest": "https://raw.githubusercontent.com/eavanvalkenburg/sia/beta/custom_components/sia/manifest.json",
-  "url": "https://github.com/eavanvalkenburg/sia"
-}

--- a/components_old/skodaconnect.json
+++ b/components_old/skodaconnect.json
@@ -1,6 +1,0 @@
-{
-  "name": "Skoda Connect",
-  "owner": ["@lendy007"],
-  "manifest": "https://raw.githubusercontent.com/lendy007/homeassistant-skodaconnect/main/custom_components/skodaconnect/manifest.json",
-  "url": "https://github.com/lendy007/homeassistant-skodaconnect"
-}

--- a/components_old/skydance.json
+++ b/components_old/skydance.json
@@ -1,6 +1,0 @@
-{
-  "name": "Skydance",
-  "owner": ["@tomasbedrich"],
-  "manifest": "https://raw.githubusercontent.com/tomasbedrich/home-assistant-skydance/master/custom_components/skydance/manifest.json",
-  "url": "https://github.com/tomasbedrich/home-assistant-skydance"
-}

--- a/components_old/skyq.json
+++ b/components_old/skyq.json
@@ -1,6 +1,0 @@
-{
-  "name": "skyq",
-  "owner": ["@rogerselwyn"],
-  "manifest": "https://raw.githubusercontent.com/RogerSelwyn/Home_Assistant_SkyQ_MediaPlayer/master/custom_components/skyq/manifest.json",
-  "url": "https://github.com/RogerSelwyn/Home_Assistant_SkyQ_MediaPlayer"
-}

--- a/components_old/slack_user.json
+++ b/components_old/slack_user.json
@@ -1,9 +1,0 @@
-{
-  "manifest": "https://raw.githubusercontent.com/GeorgeSG/ha-slack-user/master/custom_components/slack_user/manifest.json",
-  "name": "slack_user",
-  "owner": [
-    "@GeorgeSG"
-  ],
-  "url": "https://github.com/GeorgeSG/ha-slack-user"
-}
-

--- a/components_old/smartrent.json
+++ b/components_old/smartrent.json
@@ -1,6 +1,0 @@
-{
-    "manifest": "https://raw.githubusercontent.com/ZacheryThomas/homeassistant-smartrent/main/custom_components/smartrent/manifest.json",
-    "name": "SmartRent",
-    "owner": ["@zacherythomas"],
-    "url": "https://github.com/ZacheryThomas/homeassistant-smartrent"
-}

--- a/components_old/solax_modbus.json
+++ b/components_old/solax_modbus.json
@@ -1,6 +1,0 @@
-{
-  "name": "solax_modbus",
-  "owner": ["@wills106"],
-  "manifest": "https://raw.githubusercontent.com/wills106/homsassistant-solax-modbus/main/custom_components/solax_modbus/manifest.json",
-  "url": "https://github.com/wills106/homsassistant-solax-modbus"
-}

--- a/components_old/sonoff.json
+++ b/components_old/sonoff.json
@@ -1,6 +1,0 @@
-{
-  "name": "sonoff",
-  "owner": ["@AlexxIT"],
-  "manifest": "https://raw.githubusercontent.com/AlexxIT/SonoffLAN/master/custom_components/sonoff/manifest.json",
-  "url": "https://github.com/AlexxIT/SonoffLAN"
-}

--- a/components_old/sp110e.json
+++ b/components_old/sp110e.json
@@ -1,8 +1,0 @@
-{
-  "name": "sp110e",
-  "owner": [
-    "@roslovets"
-  ],
-  "manifest": "https://raw.githubusercontent.com/roslovets/SP110E-HASS/main/custom_components/sp110e/manifest.json",
-  "url": "https://github.com/roslovets/SP110E-HASS"
-}

--- a/components_old/spacex.json
+++ b/components_old/spacex.json
@@ -1,6 +1,0 @@
-{
-  "name": "SpaceX Launches and Starman",
-  "owner": ["@djtimca"],
-  "manifest": "https://raw.githubusercontent.com/djtimca/HASpaceX/master/custom_components/spacex/manifest.json",
-  "url": "https://github.com/djtimca/haspacex"
-}

--- a/components_old/sql_json.json
+++ b/components_old/sql_json.json
@@ -1,6 +1,0 @@
-{
-  "name": "SQL (JSON)",
-  "owner": ["@crowbarz"],
-  "manifest": "https://raw.githubusercontent.com/crowbarz/ha-sql_json/main/custom_components/sql_json/manifest.json",
-  "url": "https://github.com/crowbarz/ha-sql_json"
-}

--- a/components_old/steam_wishlist.json
+++ b/components_old/steam_wishlist.json
@@ -1,6 +1,0 @@
-{
-  "name": "steam_wishlist",
-  "owner": ["@boralyl"],
-  "manifest": "https://raw.githubusercontent.com/boralyl/steam-wishlist/master/custom_components/steam_wishlist/manifest.json",
-  "url": "https://github.com/boralyl/steam-wishlist"
-}

--- a/components_old/stihl_imow.json
+++ b/components_old/stihl_imow.json
@@ -1,6 +1,0 @@
-{
-  "name": "stihl_imow",
-  "owner": ["@ChrisHaPunkt"],
-  "manifest": "https://raw.githubusercontent.com/ChrisHaPunkt/ha-stihl-imow/main/custom_components/stihl_imow/manifest.json",
-  "url": "https://github.com/ChrisHaPunkt/ha-stihl-imow"
-}

--- a/components_old/sunspec.json
+++ b/components_old/sunspec.json
@@ -1,6 +1,0 @@
-{
-  "name": "SunSpec",
-  "owner": ["@CJNE"],
-  "manifest": "https://raw.githubusercontent.com/CJNE/ha-sunspec/main/custom_components/sunspec/manifest.json",
-  "url": "https://github.com/CJNE/ha-sunspec"
-}

--- a/components_old/sureha.json
+++ b/components_old/sureha.json
@@ -1,6 +1,0 @@
-{
-  "name": "Sure Petcare",
-  "owner": ["@benleb"],
-  "manifest": "https://raw.githubusercontent.com/benleb/sureha/dev/manifest.json",
-  "url": "https://github.com/benleb/sureha"
-}

--- a/components_old/svt_play.json
+++ b/components_old/svt_play.json
@@ -1,6 +1,0 @@
-{
-  "name": "SVT Play",
-  "owner": ["@lindell"],
-  "manifest": "https://raw.githubusercontent.com/lindell/home-assistant-svt-play/master/custom_components/svt_play/manifest.json",
-  "url": "https://github.com/lindell/home-assistant-svt-play"
-}

--- a/components_old/switchbot_cloud.json
+++ b/components_old/switchbot_cloud.json
@@ -1,6 +1,0 @@
-{
-  "name": "switchbot_cloud",
-  "owner": ["@stuart-c"],
-  "manifest": "https://raw.githubusercontent.com/stuart-c/homeassistant-switchbot/master/custom_components/switchbot_cloud/manifest.json",
-  "url": "https://github.com/stuart-c/homeassistant-switchbot"
-}

--- a/components_old/tahoma.json
+++ b/components_old/tahoma.json
@@ -1,6 +1,0 @@
-{
-  "name": "Somfy TaHoma",
-  "owner": ["@philklei", "@imicknl", "@vlebourl", "@tetienne"],
-  "manifest": "https://raw.githubusercontent.com/iMicknl/ha-tahoma/master/custom_components/tahoma/manifest.json",
-  "url": "https://github.com/imicknl/ha-tahoma"
-}

--- a/components_old/tapo_control.json
+++ b/components_old/tapo_control.json
@@ -1,6 +1,0 @@
-{
-    "name": "Tapo: Cameras Control",
-    "owner": ["@JurajNyiri"],
-    "manifest": "https://raw.githubusercontent.com/JurajNyiri/HomeAssistant-Tapo-Control/main/custom_components/tapo_control/manifest.json",
-    "url": "https://github.com/JurajNyiri/HomeAssistant-Tapo-Control"
-  }

--- a/components_old/tauron_amiplus.json
+++ b/components_old/tauron_amiplus.json
@@ -1,6 +1,0 @@
-{
-    "name": "Tauron AMIplus",
-    "owner": ["@PiotrMachowski"],
-    "manifest": "https://raw.githubusercontent.com/PiotrMachowski/Home-Assistant-custom-components-Tauron-AMIplus/master/custom_components/tauron_amiplus/manifest.json",
-    "url": "https://github.com/PiotrMachowski/Home-Assistant-custom-components-Tauron-AMIplus"
-}

--- a/components_old/tdameritrade.json
+++ b/components_old/tdameritrade.json
@@ -1,6 +1,0 @@
-{
-  "name": "TDAmeritrade",
-  "owner": ["@prairiesnpr"],
-  "manifest": "https://raw.githubusercontent.com/prairiesnpr/hass-tdameritrade/master/custom_components/tdameritrade/manifest.json",
-  "url": "https://github.com/prairiesnpr/hass-tdameritrade"
-}

--- a/components_old/technicolor.json
+++ b/components_old/technicolor.json
@@ -1,6 +1,0 @@
-{
-  "name": "Technicolor Custom Integration",
-  "owner": ["@shaiu"],
-  "manifest": "https://raw.githubusercontent.com/shaiu/technicolor/main/custom_components/technicolor/manifest.json",
-  "url": "https://github.com/shaiu/technicolor"
-}

--- a/components_old/teletask.json
+++ b/components_old/teletask.json
@@ -1,8 +1,0 @@
-{
-    "name": "teletask",
-    "owner": [
-        "@tiemooowh"
-    ],
-    "manifest": "https://raw.githubusercontent.com/Tiemooowh/homeassistant-teletask/main/custom_components/teletask/manifest.json",
-    "url": "https://github.com/Tiemooowh/homeassistant-teletask"
-}

--- a/components_old/tesla_custom.json
+++ b/components_old/tesla_custom.json
@@ -1,6 +1,0 @@
-{
-  "name": "Tesla Custom Integration",
-  "owner": ["@alandtse"],
-  "manifest": "https://raw.githubusercontent.com/alandtse/tesla/main/custom_components/tesla_custom/manifest.json",
-  "url": "https://github.com/alandtse/tesla"
-}

--- a/components_old/teufel_raumfeld.json
+++ b/components_old/teufel_raumfeld.json
@@ -1,6 +1,0 @@
-{
-  "name": "Teufel Raumfeld",
-  "owner": ["@B5r1oJ0A9G"],
-  "manifest": "https://raw.githubusercontent.com/B5r1oJ0A9G/teufel_raumfeld/master/custom_components/teufel_raumfeld/manifest.json",
-  "url": "https://github.com/B5r1oJ0A9G/teufel_raumfeld"
-}

--- a/components_old/tgtg.json
+++ b/components_old/tgtg.json
@@ -1,7 +1,0 @@
-
-{
-  "name": "TooGoodToGo",
-  "owner": ["@chouffy"],
-  "manifest": "https://raw.githubusercontent.com/Chouffy/home_assistant_tgtg/main/custom_components/tgtg/manifest.json",
-  "url": "https://github.com/Chouffy/home_assistant_tgtg"
-}

--- a/components_old/thermal_vision.json
+++ b/components_old/thermal_vision.json
@@ -1,6 +1,0 @@
-{
-    "name": "Thermal Vision",
-    "owner": ["@TheRealWaldo"],
-    "manifest": "https://raw.githubusercontent.com/TheRealWaldo/thermal/main/custom_components/thermal_vision/manifest.json",
-    "url": "https://github.com/TheRealWaldo/thermal"
-}

--- a/components_old/thermiagenesis.json
+++ b/components_old/thermiagenesis.json
@@ -1,6 +1,0 @@
-{
-  "name": "Thermia Genesis",
-  "owner": ["@CJNE"],
-  "manifest": "https://raw.githubusercontent.com/CJNE/thermiagenesis/master/custom_components/thermiagenesis/manifest.json",
-  "url": "https://github.com/CJNE/thermiagenesis"
-}

--- a/components_old/tns_energo.json
+++ b/components_old/tns_energo.json
@@ -1,6 +1,0 @@
-{
-  "name": "TNS Energo",
-  "owner": ["@alryaz"],
-  "manifest": "https://raw.githubusercontent.com/alryaz/hass-tns-energo/main/custom_components/tns_energo/manifest.json",
-  "url": "https://github.com/alryaz/hass-tns-energo"
-}

--- a/components_old/toshiba_ac.json
+++ b/components_old/toshiba_ac.json
@@ -1,6 +1,0 @@
-{
-    "name": "toshiba_ac",
-    "owner": ["@h4de5"],
-    "manifest": "https://raw.githubusercontent.com/h4de5/home-assistant-toshiba_ac/main/custom_components/toshiba_ac/manifest.json",
-    "url": "https://github.com/h4de5/home-assistant-toshiba_ac"
-}

--- a/components_old/toyota.json
+++ b/components_old/toyota.json
@@ -1,6 +1,0 @@
-{
-  "name": "Toyota",
-  "owner": ["@DurgNomis-drol"],
-  "manifest": "https://raw.githubusercontent.com/DurgNomis-drol/ha_toyota/master/custom_components/toyota/manifest.json",
-  "url": "https://github.com/DurgNomis-drol/ha_toyota"
-}

--- a/components_old/tplink_deco.json
+++ b/components_old/tplink_deco.json
@@ -1,6 +1,0 @@
-{
-    "name": "TP-Link Deco",
-    "owner": ["@amosyuen"],
-    "manifest": "https://raw.githubusercontent.com/amosyuen/ha-tplink-deco/master/custom_components/tplink_deco/manifest.json",
-    "url": "https://github.com/amosyuen/ha-tplink-deco"
-}

--- a/components_old/trackimo.json
+++ b/components_old/trackimo.json
@@ -1,8 +1,0 @@
-{
-    "name": "Trackimo",
-    "owner": [
-        "@troykelly"
-    ],
-    "manifest": "https://raw.githubusercontent.com/troykelly/hacs-trackimo/main/custom_components/trackimo/manifest.json",
-    "url": "https://github.com/troykelly/hacs-trackimo"
-}

--- a/components_old/tryfi.json
+++ b/components_old/tryfi.json
@@ -1,6 +1,0 @@
-{
-  "name": "tryfi",
-  "owner": ["@sbabcock23"],
-  "manifest": "https://raw.githubusercontent.com/sbabcock23/hass-tryfi/master/custom_components/tryfi/manifest.json",
-  "url": "https://github.com/sbabcock23/hass-tryfi"
-}

--- a/components_old/ubee.json
+++ b/components_old/ubee.json
@@ -1,6 +1,0 @@
-{
-  "name": "Ubee Router",
-  "owner": ["@mzdrale", "@kevinhaendel"],
-  "manifest": "https://raw.githubusercontent.com/kevinhaendel/ha-ubee/main/custom_components/ubee/manifest.json",
-  "url": "https://github.com/kevinhaendel/ha-ubee"
-}

--- a/components_old/uhoo.json
+++ b/components_old/uhoo.json
@@ -1,6 +1,0 @@
-{
-    "name": "uHoo",
-    "owner": ["@csacca"],
-    "manifest": "https://raw.githubusercontent.com/csacca/uhoo-homeassistant/master/custom_components/uhoo/manifest.json",
-    "url": "https://github.com/csacca/uhoo-homeassistant"
-}

--- a/components_old/ukho_tides.json
+++ b/components_old/ukho_tides.json
@@ -1,6 +1,0 @@
-{
-    "name": "ukho_tides",
-    "owner": ["@ianByrne"],
-    "manifest": "https://raw.githubusercontent.com/ianByrne/HASS-ukho_tides/main/custom_components/ukho_tides/manifest.json",
-    "url": "https://github.com/ianByrne/HASS_Integration_UKHOTides"
-}

--- a/components_old/ultrasync.json
+++ b/components_old/ultrasync.json
@@ -1,6 +1,0 @@
-{
-  "name": "ultrasync",
-  "owner": ["@caronc"],
-  "manifest": "https://raw.githubusercontent.com/caronc/ha-ultrasync/main/custom_components/ultrasync/manifest.json",
-  "url": "https://github.com/caronc/ha-ultrasync"
-}

--- a/components_old/uponor.json
+++ b/components_old/uponor.json
@@ -1,6 +1,0 @@
-{
-  "name": "Uponor Smatrix Pulse X-265 heating",
-  "owner": ["@asev"],
-  "manifest": "https://raw.githubusercontent.com/asev/homeassistant-uponor/master/custom_components/uponor/manifest.json",
-  "url": "https://github.com/asev/homeassistant-uponor"
-}

--- a/components_old/usr_r16.json
+++ b/components_old/usr_r16.json
@@ -1,6 +1,0 @@
-{
-    "name": "USR-R16",
-    "owner": ["@blindlight"],
-    "manifest": "https://raw.githubusercontent.com/blindlight86/HA_USR-R16/master/custom_components/usr_r16/manifest.json",
-    "url": "https://github.com/blindlight86/HA_USR-R16"
-  }

--- a/components_old/uvfive.json
+++ b/components_old/uvfive.json
@@ -1,6 +1,0 @@
-{
-  "name": "uvFive MIoT device",
-  "owner": ["@vaughan-zeng"],
-  "manifest": "https://raw.githubusercontent.com/vaughan-zeng/uvfive_miot/master/custom_components/uvfive/manifest.json",
-  "url": "https://github.com/vaughan-zeng/uvfive_miot"
-}

--- a/components_old/veolia.json
+++ b/components_old/veolia.json
@@ -1,6 +1,0 @@
-{
-  "name": "Veolia",
-  "owner": ["@tetienne"],
-  "manifest": "https://raw.githubusercontent.com/tetienne/veolia-custom-component/master/custom_components/veolia/manifest.json",
-  "url": "https://github.com/tetienne/veolia-custom-component"
-}

--- a/components_old/victorsmartkill.json
+++ b/components_old/victorsmartkill.json
@@ -1,6 +1,0 @@
-{
-  "name": "Victor Smart-Kill",
-  "owner": ["@toreamun"],
-  "manifest": "https://raw.githubusercontent.com/toreamun/victorsmartkill-homeassistant/master/custom_components/victorsmartkill/manifest.json",
-  "url": "https://github.com/toreamun/victorsmartkill-homeassistant"
-}

--- a/components_old/viomise.json
+++ b/components_old/viomise.json
@@ -1,6 +1,0 @@
-{
-  "name": "viomise",
-  "owner": ["@marotoweb"],
-  "manifest": "https://raw.githubusercontent.com/marotoweb/home-assistant-vacuum-viomise/master/custom_components/viomise/manifest.json",
-  "url": "https://github.com/marotoweb/home-assistant-vacuum-viomise"
-}

--- a/components_old/vivint.json
+++ b/components_old/vivint.json
@@ -1,8 +1,0 @@
-{
-  "name": "Vivint",
-  "owner": [
-    "@natekspencer"
-  ],
-  "manifest": "https://raw.githubusercontent.com/natekspencer/hacs-vivint/main/custom_components/vivint/manifest.json",
-  "url": "https://github.com/natekspencer/hacs-vivint"
-}

--- a/components_old/volkswagencarnet.json
+++ b/components_old/volkswagencarnet.json
@@ -1,6 +1,0 @@
-{
-  "name": "Volkswagen WeConnect",
-  "owner": ["@robinostlund"],
-  "manifest": "https://raw.githubusercontent.com/robinostlund/homeassistant-volkswagencarnet/master/custom_components/volkswagencarnet/manifest.json",
-  "url": "https://github.com/robinostlund/homeassistant-volkswagencarnet"
-}

--- a/components_old/vulcan.json
+++ b/components_old/vulcan.json
@@ -1,6 +1,0 @@
-{
-    "name": "Uonet+ Vulcan",
-    "owner": ["@Antoni-Czaplicki"],
-    "manifest": "https://raw.githubusercontent.com/Antoni-Czaplicki/vulcan-for-hassio/master/custom_components/vulcan/manifest.json",
-    "url": "https://github.com/Antoni-Czaplicki/vulcan-for-hassio"
-}

--- a/components_old/waste_collection_schedule.json
+++ b/components_old/waste_collection_schedule.json
@@ -1,6 +1,0 @@
-{
-  "name": "Waste Collection Schedule",
-  "owner": ["@mampfes"],
-  "manifest": "https://raw.githubusercontent.com/mampfes/hacs_waste_collection_schedule/master/custom_components/waste_collection_schedule/manifest.json",
-  "url": "https://github.com/mampfes/hacs_waste_collection_schedule"
-}

--- a/components_old/wattbox.json
+++ b/components_old/wattbox.json
@@ -1,8 +1,0 @@
-{
-  "name": "WattBox",
-  "owner": [
-    "@eseglem"
-  ],
-  "manifest": "https://raw.githubusercontent.com/eseglem/hass-wattbox/master/custom_components/wattbox/manifest.json",
-  "url": "https://github.com/eseglem/hass-wattbox"
-}

--- a/components_old/wavinsentio.json
+++ b/components_old/wavinsentio.json
@@ -1,6 +1,0 @@
-{
-  "name": "Wavin Sentio",
-  "owner": ["@djerik"],
-  "manifest": "https://raw.githubusercontent.com/djerik/wavinsentio-ha/master/custom_components/wavinsentio/manifest.json",
-  "url": "https://github.com/djerik/wavinsentio-ha"
-}

--- a/components_old/weatherbit.json
+++ b/components_old/weatherbit.json
@@ -1,6 +1,0 @@
-{
-  "name": "Weatherbit",
-  "owner": ["@briis"],
-  "manifest": "https://raw.githubusercontent.com/briis/weatherbit/master/custom_components/weatherbit/manifest.json",
-  "url": "https://github.com/briis/weatherbit"
-}

--- a/components_old/weenect.json
+++ b/components_old/weenect.json
@@ -1,7 +1,0 @@
-{
-    "name": "weenect",
-    "owner": ["@eifinger"],
-    "manifest": "https://raw.githubusercontent.com/eifinger/hass-weenect/master/custom_components/weenect/manifest.json",
-    "url": "https://github.com/eifinger/hass-weenect"
-  }
-  

--- a/components_old/wemportal.json
+++ b/components_old/wemportal.json
@@ -1,6 +1,0 @@
-{
-  "name": "Weishaupt WEM Portal",
-  "owner": ["@erikkastelec"],
-  "manifest": "https://raw.githubusercontent.com/erikkastelec/hass-WEM-Portal/master/custom_components/wemportal/manifest.json",
-  "url": "https://github.com/erikkastelec/hass-WEM-Portal"
-}

--- a/components_old/winix.json
+++ b/components_old/winix.json
@@ -1,6 +1,0 @@
-{
-  "name": "winix",
-  "owner": ["@iprak"],
-  "manifest": "https://raw.githubusercontent.com/iprak/winix/main/custom_components/winix/manifest.json",
-  "url": "https://github.com/iprak/winix"
-}

--- a/components_old/worldtidesinfocustom.json
+++ b/components_old/worldtidesinfocustom.json
@@ -1,6 +1,0 @@
-{
-  "name": "WorldTidesInfoCustom",
-  "owner": ["@jugla"],
-  "manifest": "https://raw.githubusercontent.com/jugla/worldtidesinfocustom/main/custom_components/worldtidesinfocustom/manifest.json",
-  "url": "https://github.com/jugla/worldtidesinfocustom"
-}

--- a/components_old/wort_des_tages.json
+++ b/components_old/wort_des_tages.json
@@ -1,7 +1,0 @@
-
-{
-  "name": "Wort des Tages",
-  "owner": ["@Ludy87"],
-  "manifest": "https://raw.githubusercontent.com/Ludy87/astra_germany_wort_des_tages/main/custom_components/wort_des_tages/manifest.json",
-  "url": "https://github.com/Ludy87/astra_germany_wort_des_tages"
-}

--- a/components_old/wyzeapi.json
+++ b/components_old/wyzeapi.json
@@ -1,6 +1,0 @@
-{
-  "name": "Wyze Integration",
-  "owner": ["@JoshuaMulliken"],
-  "manifest": "https://raw.githubusercontent.com/JoshuaMulliken/ha-wyzeapi/master/custom_components/wyzeapi/manifest.json",
-  "url": "https://github.com/JoshuaMulliken/ha-wyzeapi"
-}

--- a/components_old/xiaomi_cloud_map_extractor.json
+++ b/components_old/xiaomi_cloud_map_extractor.json
@@ -1,6 +1,0 @@
-{
-    "name": "Xiaomi Cloud Map Extractor",
-    "owner": ["@PiotrMachowski"],
-    "manifest": "https://raw.githubusercontent.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor/master/custom_components/xiaomi_cloud_map_extractor/manifest.json",
-    "url": "https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor"
-}

--- a/components_old/xiaomi_gateway3.json
+++ b/components_old/xiaomi_gateway3.json
@@ -1,6 +1,0 @@
-{
-  "name": "xiaomi_gateway3",
-  "owner": ["@AlexxIT"],
-  "manifest": "https://raw.githubusercontent.com/AlexxIT/XiaomiGateway3/master/custom_components/xiaomi_gateway3/manifest.json",
-  "url": "https://github.com/AlexxIT/XiaomiGateway3"
-}

--- a/components_old/xiaomi_miio_airconditioningcompanion.json
+++ b/components_old/xiaomi_miio_airconditioningcompanion.json
@@ -1,6 +1,0 @@
-{
-  "name": "xiaomi_miio_airconditioningcompanion",
-  "owner": ["@syssi"],
-  "manifest": "https://raw.githubusercontent.com/syssi/xiaomi_airconditioningcompanion/develop/custom_components/xiaomi_miio_airconditioningcompanion/manifest.json",
-  "url": "https://github.com/syssi/xiaomi_airconditioningcompanion"
-}

--- a/components_old/xiaomi_miio_airpurifier.json
+++ b/components_old/xiaomi_miio_airpurifier.json
@@ -1,6 +1,0 @@
-{
-  "name": "xiaomi_miio_airpurifier",
-  "owner": ["@syssi"],
-  "manifest": "https://raw.githubusercontent.com/syssi/xiaomi_airpurifier/develop/custom_components/xiaomi_miio_airpurifier/manifest.json",
-  "url": "https://github.com/syssi/xiaomi_airpurifier"
-}

--- a/components_old/xiaomi_miio_cooker.json
+++ b/components_old/xiaomi_miio_cooker.json
@@ -1,6 +1,0 @@
-{
-  "name": "xiaomi_miio_cooker",
-  "owner": ["@syssi"],
-  "manifest": "https://raw.githubusercontent.com/syssi/xiaomi_cooker/develop/custom_components/xiaomi_miio_cooker/manifest.json",
-  "url": "https://github.com/syssi/xiaomi_cooker"
-}

--- a/components_old/xiaomi_miio_fan.json
+++ b/components_old/xiaomi_miio_fan.json
@@ -1,6 +1,0 @@
-{
-  "name": "xiaomi_miio_fan",
-  "owner": ["@syssi"],
-  "manifest": "https://raw.githubusercontent.com/syssi/xiaomi_fan/develop/custom_components/xiaomi_miio_fan/manifest.json",
-  "url": "https://github.com/syssi/xiaomi_fan"
-}

--- a/components_old/xiaomi_miio_philipslight.json
+++ b/components_old/xiaomi_miio_philipslight.json
@@ -1,6 +1,0 @@
-{
-  "name": "xiaomi_miio_philipslight",
-  "owner": ["@syssi"],
-  "manifest": "https://raw.githubusercontent.com/syssi/philipslight/develop/custom_components/xiaomi_miio_philipslight/manifest.json",
-  "url": "https://github.com/syssi/philipslight"
-}

--- a/components_old/xiaomi_miio_plug.json
+++ b/components_old/xiaomi_miio_plug.json
@@ -1,6 +1,0 @@
-{
-  "name": "xiaomi_miio_plug",
-  "owner": ["@syssi"],
-  "manifest": "https://raw.githubusercontent.com/syssi/xiaomiplug/develop/custom_components/xiaomi_miio_plug/manifest.json",
-  "url": "https://github.com/syssi/xiaomiplug"
-}

--- a/components_old/xiaomi_miio_raw.json
+++ b/components_old/xiaomi_miio_raw.json
@@ -1,6 +1,0 @@
-{
-  "name": "xiaomi_miio_raw",
-  "owner": ["@syssi"],
-  "manifest": "https://raw.githubusercontent.com/syssi/xiaomi_raw/develop/custom_components/xiaomi_miio_raw/manifest.json",
-  "url": "https://github.com/syssi/xiaomi_raw"
-}

--- a/components_old/xiaomi_miot.json
+++ b/components_old/xiaomi_miot.json
@@ -1,6 +1,0 @@
-{
-  "name": "xiaomi_miot",
-  "owner": ["@al-one"],
-  "manifest": "https://raw.githubusercontent.com/al-one/hass-xiaomi-miot/master/custom_components/xiaomi_miot/manifest.json",
-  "url": "https://github.com/al-one/hass-xiaomi-miot"
-}

--- a/components_old/xiaomi_miot_raw.json
+++ b/components_old/xiaomi_miot_raw.json
@@ -1,6 +1,0 @@
-{
-  "name": "xiaomi_miot_raw",
-  "owner": ["@ha0y"],
-  "manifest": "https://raw.githubusercontent.com/ha0y/xiaomi_miot_raw/master/custom_components/xiaomi_miot_raw/manifest.json",
-  "url": "https://github.com/ha0y/xiaomi_miot_raw"
-}

--- a/components_old/xiaomi_viomi.json
+++ b/components_old/xiaomi_viomi.json
@@ -1,6 +1,0 @@
-{
-    "name": "Xiaomi Viomi",
-    "owner": ["@nergal"],
-    "manifest": "https://raw.githubusercontent.com/nergal/homeassistant-vacuum-viomi/master/custom_components/xiaomi_viomi/manifest.json",
-    "url": "https://github.com/nergal/homeassistant-vacuum-viomi"
-}

--- a/components_old/yandex_music_browser.json
+++ b/components_old/yandex_music_browser.json
@@ -1,6 +1,0 @@
-{
-  "name": "Yandex Music Browser",
-  "owner": ["@alryaz"],
-  "manifest": "https://raw.githubusercontent.com/alryaz/hass-yandex-music-browser/main/custom_components/yandex_music_browser/manifest.json",
-  "url": "https://github.com/alryaz/hass-yandex-music-browser"
-}

--- a/components_old/yeelight_bt.json
+++ b/components_old/yeelight_bt.json
@@ -1,6 +1,0 @@
-{
-  "name": "yeelight_bt",
-  "owner": ["@hcoohb"],
-  "manifest": "https://raw.githubusercontent.com/hcoohb/hass-yeelightbt/master/custom_components/yeelight_bt/manifest.json",
-  "url": "https://github.com/hcoohb/hass-yeelightbt"
-}

--- a/components_old/ytube_music_player.json
+++ b/components_old/ytube_music_player.json
@@ -1,6 +1,0 @@
-{
-  "name": "ytube_music_player",
-  "owner": ["@KoljaWindeler"],
-  "manifest": "https://raw.githubusercontent.com/KoljaWindeler/ytube_music_player/main/custom_components/ytube_music_player/manifest.json",
-  "url": "https://github.com/KoljaWindeler/ytube_music_player"
-}

--- a/components_old/zadnego_ale.json
+++ b/components_old/zadnego_ale.json
@@ -1,6 +1,0 @@
-{
-  "name": "Żadnego Ale",
-  "owner": ["@bieniu"],
-  "manifest": "https://raw.githubusercontent.com/bieniu/ha-zadnego-ale/main/custom_components/zadnego_ale/manifest.json",
-  "url": "https://github.com/bieniu/ha-zadnego-ale"
-}

--- a/components_old/zaptec.json
+++ b/components_old/zaptec.json
@@ -1,6 +1,0 @@
-{
-    "name": "zaptec",
-    "owner": ["@Hellowlol"],
-    "manifest": "https://raw.githubusercontent.com/custom-components/zaptec/master/custom_components/zaptec/manifest.json",
-    "url": "https://github.com/custom-components/zaptec"
-}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,6 @@
+pyamdgpuinfo
+pybase64
+rapidfuzz
 RPi.GPIO
+rrdtool
+smbus_cffi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pyamdgpuinfo
 pybase64
 rapidfuzz
 RPi.GPIO

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pybase64
-rapidfuzz
 RPi.GPIO
 rrdtool
 smbus_cffi


### PR DESCRIPTION
This PR migrates the old components to the new structure.

- I've downloaded all manifests of all known custom integrations in this repo
- extracted all requirements from all of them
- Removed all version pins/ranges
- Removed all duplicate requirements
- Removed all requirements that are already in Core requirements.txt and requirements_all.txt
- Removed all requirements for which we already have a musl wheel
- For the remainder I removed the ones that have a wheel already available on PyPi (`*-none-any.whl`)
- Leftovers I've looked up to see if they need help with compiling and providing actual musl wheels.

The result of the above is in this PR. I skipped `pyamdgpuinfo`, as that one wouldn't work for our situation anyways (so no need to build a wheel for it).