### PR TITLE
Add wheels for SPI bus access

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ RPi.GPIO
 rrdtool
 Shapely
 smbus_cffi
+spidev


### PR DESCRIPTION
This changes aim to add the wheel for the `spidev` wheel, to access the SPI bus from a custom integration.

## Why?
In the `musllinux` set of wheels in `https://wheels.home-assistant.io/`, this wheel is not present, so the python environment packaged with Home Assistant tries to build it, but not being able to find `gcc` fails the build. 

This package provides an implementation of a client library that custom integrations can use to access the SPI bus. 

I am aware that Home assistant does not support GPIO related integrations packaged with `core` releases, but AFAIK it should still be available for custom integrations [source](https://github.com/home-assistant/architecture/blob/780ea1b180263fce7b08805c019dd580f3db6fe2/adr/0019-GPIO.md).

Cheers!