### PR TITLE
Add wheels building for the cp311 ABI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: ["aarch64", "armhf", "armv7", "amd64", "i386"]
-        abi: ["cp310"]
+        abi: ["cp310", "cp311"]
 
     steps:
       - name: Check out code from GitHub


### PR DESCRIPTION
SSIA, start building wheels for Python 3.11