### PR TITLE
Don't try to build Shapely on armhf

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -69,6 +69,13 @@ jobs:
         run: |
           touch .env_file
 
+      - name: (Un)comment packages
+        run: |
+          # Some packages are not buildable on armhf anymore
+          if [ "${{ matrix.arch }}" = "armhf" ]; then
+            sed -i "s|Shapely|# Shapely|g" requirements.txt
+          fi
+
       - name: Build wheels
         uses: home-assistant/wheels@2024.01.0
         with:


### PR DESCRIPTION
Our custom wheels building CI has been broken for quite a while now, thanks to the Shapely package.

We just can't get that to build on armhf. This PR add in the same uncomment logic as we use on Core, to just skip Shapely on armhf builds.