### PR TITLE
Build wheels for CPython ABI cp312

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: ["aarch64", "armhf", "armv7", "amd64", "i386"]
-        abi: ["cp311"]
+        abi: ["cp311", "cp312"]
 
     steps:
       - name: Check out code from GitHub


### PR DESCRIPTION
As of the next release, we will be shipping with Python 3.12

This PR ensures we also build our custom wheels for it.