### PR TITLE
Add telnetlib3 for custom integration 4noks_elios4you

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ rrdtool
 Shapely
 smbus_cffi
 spidev
+telnetlib3


### PR DESCRIPTION
Developing a new custom integration for Elios4you energy monitoring device.
The device data can be fetched only through telnet, so I'm using telnetlib3 to fetch data.

Thanks.