### PR TITLE
Add aiortc

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -88,4 +88,4 @@ jobs:
           test: ${{ steps.test.outputs.is_test }}
           constraints: "constraints.txt"
           requirements: "requirements.txt"
-          apk: "libffi-dev;rrdtool-dev;geos-dev;opus-dev;libvpx-dev;ffmpeg-dev"
+          apk: "libffi-dev;rrdtool-dev;geos-dev;opus-dev;libvpx-dev;ffmpeg-dev;libsrtp-dev"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -88,4 +88,4 @@ jobs:
           test: ${{ steps.test.outputs.is_test }}
           constraints: "constraints.txt"
           requirements: "requirements.txt"
-          apk: "libffi-dev;rrdtool-dev;geos-dev;opus-dev;libvpx-dev"
+          apk: "libffi-dev;rrdtool-dev;geos-dev;opus-dev;libvpx-dev;ffmpeg-dev"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -88,4 +88,4 @@ jobs:
           test: ${{ steps.test.outputs.is_test }}
           constraints: "constraints.txt"
           requirements: "requirements.txt"
-          apk: "libffi-dev;rrdtool-dev;geos-dev"
+          apk: "libffi-dev;rrdtool-dev;geos-dev;opus-dev;libvpx-dev"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -88,4 +88,4 @@ jobs:
           test: ${{ steps.test.outputs.is_test }}
           constraints: "constraints.txt"
           requirements: "requirements.txt"
-          apk: "libffi-dev;rrdtool-dev;geos-dev;opus-dev;libvpx-dev;ffmpeg-dev;libsrtp-dev;libssl-dev"
+          apk: "libffi-dev;rrdtool-dev;geos-dev;opus-dev;libvpx-dev;ffmpeg-dev;libsrtp-dev;libressl-dev"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -88,4 +88,4 @@ jobs:
           test: ${{ steps.test.outputs.is_test }}
           constraints: "constraints.txt"
           requirements: "requirements.txt"
-          apk: "libffi-dev;rrdtool-dev;geos-dev;opus-dev;libvpx-dev;ffmpeg-dev;libsrtp-dev"
+          apk: "libffi-dev;rrdtool-dev;geos-dev;opus-dev;libvpx-dev;ffmpeg-dev;libsrtp-dev;libssl-dev"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ rrdtool
 Shapely
 smbus_cffi
 spidev
+aiortc


### PR DESCRIPTION
Adds [aiortc](https://github.com/aiortc/aiortc) for the [sip client integration](https://github.com/TECH7Fox/sipclient-hass-integration) I am working on. Currently testing it on a debian HA container, but for public testing and eventually a release I need this to install `aiortc` on HA-OS.

Can't easily test this myself, can the workflow get approved please? Will update if there are any issues. :)