### PR TITLE
feat: add marisa-trie

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiortc
+marisa-trie
 pybase64
 RPi.GPIO
 rrdtool


### PR DESCRIPTION
We have a small local catastrophe in one of custom components. 3.12 upgrade left us without per-compiled wheel for `marisa-trie`.
https://github.com/DurgNomis-drol/ha_toyota/issues/258

I did fix that with cross-system QEMU build for `aarch64`, but `armv?l` is not supported by that.
https://github.com/pytries/marisa-trie/pull/101
https://github.com/pytries/marisa-trie/pull/102
https://github.com/piwheels/piwheels/issues/346

Maybe this is the correct place to provide a wheel for 32-bit Raspberries?
