### PR TITLE
feat: add scikit-learn

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -88,4 +88,4 @@ jobs:
           test: ${{ steps.test.outputs.is_test }}
           constraints: "constraints.txt"
           requirements: "requirements.txt"
-          apk: "libffi-dev;rrdtool-dev;geos-dev;opus-dev;libvpx-dev;ffmpeg-dev;libsrtp-dev;libressl-dev;gfortran"
+          apk: "libffi-dev;rrdtool-dev;geos-dev;opus-dev;libvpx-dev;ffmpeg-dev;libsrtp-dev;libressl-dev;gfortran;openblas"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -88,4 +88,4 @@ jobs:
           test: ${{ steps.test.outputs.is_test }}
           constraints: "constraints.txt"
           requirements: "requirements.txt"
-          apk: "libffi-dev;rrdtool-dev;geos-dev;opus-dev;libvpx-dev;ffmpeg-dev;libsrtp-dev;libressl-dev"
+          apk: "libffi-dev;rrdtool-dev;geos-dev;opus-dev;libvpx-dev;ffmpeg-dev;libsrtp-dev;libressl-dev;gfortran"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -88,4 +88,4 @@ jobs:
           test: ${{ steps.test.outputs.is_test }}
           constraints: "constraints.txt"
           requirements: "requirements.txt"
-          apk: "libffi-dev;rrdtool-dev;geos-dev;opus-dev;libvpx-dev;ffmpeg-dev;libsrtp-dev;libressl-dev;gfortran;openblas"
+          apk: "libffi-dev;rrdtool-dev;geos-dev;opus-dev;libvpx-dev;ffmpeg-dev;libsrtp-dev;libressl-dev;gfortran;openblas;xsimd"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -88,4 +88,4 @@ jobs:
           test: ${{ steps.test.outputs.is_test }}
           constraints: "constraints.txt"
           requirements: "requirements.txt"
-          apk: "libffi-dev;rrdtool-dev;geos-dev;opus-dev;libvpx-dev;ffmpeg-dev;libsrtp-dev;libressl-dev;gfortran;openblas;xsimd"
+          apk: "libffi-dev;rrdtool-dev;geos-dev;opus-dev;libvpx-dev;ffmpeg-dev;libsrtp-dev;libressl-dev;openblas-dev"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Shapely
 smbus_cffi
 spidev
 uvloop
+scikit-learn


### PR DESCRIPTION
For a custom component i'm working on/ thinking about releasing, I need scikit-learn to be wheeled for alpine. 

This is an issue others have had in the past: https://community.home-assistant.io/t/how-to-use-scikit-learn-with-a-custom-intigration/536939

https://github.com/home-assistant/operating-system/issues/3040

scikit-learn has decided as of a few months ago the do not plan to release a musllinux wheel https://github.com/scikit-learn/scikit-learn/issues/27004#issuecomment-1966926217

I can rebuild the model I want to use from scratch, but I would prefer to just be able to use a robust and optimized model like what scikit-learn has. I am trying to use a decision tree inducer and seemingly most other packages out there either a) aren't as good as scikit-learn by a lot or b) use scikit-learn under the hood. If this isn't ideal for any reason, that's okay, just let me know.

Thanks!