### PR TITLE
Add questdb python client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Shapely
 smbus_cffi
 spidev
 uvloop
+questdb


### PR DESCRIPTION
Add [questdb python client](https://pypi.org/project/questdb/) ([repo](https://github.com/questdb/py-questdb-client)) required by [QSS](https://github.com/CM000n/qss) custom integration. The upstream doesn't provide wheels for musl linux armv7.