### PR TITLE
Add blake3 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Shapely
 smbus_cffi
 spidev
 uvloop
+blake3


### PR DESCRIPTION
May be used in alarmo in the near future : [#1030](https://github.com/nielsfaber/alarmo/pull/1030#:~:text=There%27s%20still%20one%20problem%2C%20blake3%27s%20python%20module%20needs%20rust/cargo%20and%20gcc%20to%20build%2C%20but%20I%20don%27t%20know%20how%20an%20HA%20integration%20can%20install%20these%20dependencies.)