### PR TITLE
Add onnxruntime to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aiogithubapi
 aiortc
 marisa-trie
+onnxruntime
 pybase64
 RPi.GPIO
 rrdtool


### PR DESCRIPTION
I am developing a vector search component for LLMs in a  custom component using [chromadb](https://github.com/chroma-core/chroma) and getting this error:

```
2024-10-13 12:36:57.643 ERROR (SyncWorker_37) [homeassistant.util.package] Unable to install package chromadb>=0.5.9: × No solution found when resolving dependencies:
╰─▶ Because only the following versions of onnxruntime are available:
onnxruntime<=1.14.1
onnxruntime==1.15.0
onnxruntime==1.15.1
onnxruntime==1.16.0
onnxruntime==1.16.1
onnxruntime==1.16.2
onnxruntime==1.16.3
onnxruntime==1.17.0
onnxruntime==1.17.1
onnxruntime==1.17.3
onnxruntime==1.18.0
onnxruntime==1.18.1
onnxruntime==1.19.0
onnxruntime==1.19.2
and onnxruntime>=1.14.1 has no wheels with a matching Python ABI tag, we
can conclude that onnxruntime>=1.14.1,<1.15.0 cannot be used.
And because chromadb>=0.5.9 depends on onnxruntime>=1.14.1, we can
conclude that chromadb>=0.5.9 cannot be used.
And because only the following versions of chromadb are available:
chromadb<=0.5.9
chromadb==0.5.10
chromadb==0.5.11
chromadb==0.5.12
chromadb==0.5.13
and you require chromadb>=0.5.9, we can conclude that your requirements
are unsatisfiable.
```

I believe I interpret this to mean that having a wheel available can help this issue. This package upstream doesn't want to make wheels for all platforms: https://github.com/microsoft/onnxruntime/issues/4489
