### PR TITLE
Add airtouch2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ Shapely
 smbus_cffi
 spidev
 uvloop
+airtouch2


### PR DESCRIPTION
Add [https://pypi.org/project/airtouch2/](https://pypi.org/project/airtouch2/) repo [https://github.com/nathanvdh/airtouch2-python](https://github.com/nathanvdh/airtouch2-python)
.... required for both:
[https://github.com/nathanvdh/homeassistant-airtouch2](https://github.com/nathanvdh/homeassistant-airtouch2) 
[https://github.com/nathanvdh/homeassistant-airtouch2plus](https://github.com/nathanvdh/homeassistant-airtouch2plus)

Fixes nathanvdh/homeassistant-airtouch2#20

