### PR TITLE
Remove Pyhton 3.12 from Wheels building

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: ["aarch64", "armhf", "armv7", "amd64", "i386"]
-        abi: ["cp312", "cp313"]
+        abi: ["cp313"]
 
     steps:
       - name: Check out code from GitHub


### PR DESCRIPTION
SSIA, we don't build 3.12 wheels anymore, this is the last place that wasn't cleaned up yet.

../Frenck