### PR TITLE
Add tiktoken requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ smbus_cffi
 spidev
 uvloop
 questdb
+tiktoken


### PR DESCRIPTION
I have a custom integration that ultimately depends on tiktoken, which currently publishes [wheels](https://pypi.org/project/tiktoken/#files) for musl on 86_64 and glibc on aarch64, but not musl/aarch64, so users with raspberry-pi based Home Assistant installations cannot use my integration.  I realize Home Assistant prefers that libraries build musl wheels themselves, and the OpenAI maintainer has indicated a willingness to do so in [this](https://github.com/openai/tiktoken/issues/350) thread, but releases on the project seem very infrequent, so I'm hoping this will be acceptable as a short-term solution until the project is building raspberry-pi HAOS compatible wheels on its own.