### PR TITLE
Bump aiogithubapi to 25.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiogithubapi
+aiogithubapi==25.5.0
 aiortc
 marisa-trie
 pybase64


### PR DESCRIPTION
Currently, the builder insists on building 24.6.0; this is an attempt to force it to do a newer one.