### PR TITLE
Add ortools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aiogithubapi
 aiortc
 marisa-trie
+ortools
 pybase64
 RPi.GPIO
 rrdtool


### PR DESCRIPTION
Package is not natively available (build) for musl on aarch64