### PR TITLE
add libosdp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ spidev
 uvloop
 questdb
 tiktoken
+libosdp


### PR DESCRIPTION
Please consider adding libosdp, it currently doesn't provide musl binaries for all archs. This is required for OSDP integration I'm working on.