### PR TITLE
Add lightgbm for statistical learning integrations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 RPi.GPIO
 smbus_cffi
 spidev
+lightgbm


### PR DESCRIPTION
Would it be possible to add lightgbm? I'm working on a custom integration for a self-learning solar forecast (i.e. take historic data from energy dashboard + weather data to train a solar forecasting model).

Results already look promising in back testing (this is for my own solar array):
<img width="1757" height="764" alt="image" src="https://github.com/user-attachments/assets/4ac64039-f812-4068-9c0b-28b1f51440c7" />


Now I want to create the integration around it and found lightgbm to not have musl wheels.

From what I understand, they're not publishing them, because they depend on scipy, and scipy is missing some arches for musl wheels, too.
But the HA wheels repo seems to have the missing scipy wheels, so I'd guess it could be built for HA?


