### PR TITLE
Remove marisa-trie

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 aiogithubapi
 aiortc
-marisa-trie
 pybase64
 RPi.GPIO
 Shapely


### PR DESCRIPTION
Remove marisa-trie as wheels are directly uploaded to pypi: https://pypi.org/project/marisa-trie/#files
<img width="563" height="119" alt="grafik" src="https://github.com/user-attachments/assets/a948a895-be79-4767-9678-db85c5ff9812" />
