### PR TITLE
Remove aiortc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 aiogithubapi
-aiortc
 RPi.GPIO
 smbus_cffi
 spidev


### PR DESCRIPTION
Remove aiortc as it's a pure Python lib nowadays and wheels are directly uploaded to pypi: https://pypi.org/project/aiortc/#files
<img width="429" height="63" alt="grafik" src="https://github.com/user-attachments/assets/29cad63c-1e64-4cc8-b53d-5785649e8685" />
