### PR TITLE
Add libosdp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 RPi.GPIO
 smbus_cffi
 spidev
+libosdp


### PR DESCRIPTION
Please add libosdp. While the maintainer provides wheels, it's impractical with regards to python version upgrades. HA recently migrated to 3.14 for which wheels are not available yet and that broke the integration. It would make more sense to maintain the wheels by HA so that python versions are always in sync.